### PR TITLE
Sravan-DOSE-Surveillance-07012025-1100

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,6 +12,7 @@ import AgeChart from './components/AgeChart';
 import SexChart from './components/SexChart';
 import SexAgeChart from './components/SexAgeChart';
 import UpDownArrow from './components/UpDownArrow';
+import AngleArrow from './components/AngleArrow';
 import ReactTooltip from 'react-tooltip';
 import Context from './context';
 import 'rc-slider/assets/index.css';
@@ -1764,7 +1765,7 @@ const getYears = (startYrInp, endYrInp) => {
           <span className="callout" style={{ 'color': drugColor }}>{isNaN(usRate) ? 'N/A' : `${Number(usRate).toFixed(1)}`}</span>
           <div>
             <span className='data-bite-title' style={{ color: drugColor }}>
-              {timeline} Suspected Nonfatal Overdose Visits for {drugOptions[currentDrug].titleAll}</span>
+              Monthly Suspected Nonfatal Overdose Visits for {drugOptions[currentDrug].titleAll}</span>
               <p>Per 10,000 total ED visits</p>
           </div>
         </div>
@@ -1800,7 +1801,7 @@ const getYears = (startYrInp, endYrInp) => {
         <div style={{'borderLeft': '5px solid' + drugColor}}>
           <span className="callout" style={{'color': drugColor}}>{jurisCount}</span>
           <div>
-            <span className='data-bite-title' style={{ color: drugColor }}>Jurisdictions Participating<sup>5</sup></span>
+            <span className='data-bite-title' style={{ color: drugColor }}>Jurisdictions Participating<sup>1</sup></span>
             <p>Funded states with reported Data</p>
           </div>
         </div>
@@ -2033,12 +2034,12 @@ const getYears = (startYrInp, endYrInp) => {
           <div style={{'width':'100%', 'backgroundColor': getHeaderColor(selectedDrugsLine)}}>
             {timelineLine == 'Monthly' &&
           <h2 className="data-bite-header">
-            Suspected Nonfatal Overdose ED Visits per 10,000 Total ED Visits {selectedDrugsLine.length > 1 ? '' : ('Involving ' + drugOptions[selectedDrugsLine[0]].titleForDropDown)} in {currentStateLine == 'US' ? Object.keys(jurisForDropDownLine).length + ' Participating Jurisdictions' : stateNames[currentStateLine]}, {monthNames[Number(lookupPeriodStartMonthM)] + ' ' + lookupPeriodStartYearM + ' - ' + monthNames[Number(lookupPeriodEndMonthM)] + ' ' + lookupPeriodEndYearM}
+            Suspected Nonfatal Overdose ED Visits {selectedDrugsLine.length > 1 ? '' : ('Involving ' + drugOptions[selectedDrugsLine[0]].titleForDropDown)} per 10,000 Total ED Visits in {currentStateLine == 'US' ? Object.keys(jurisForDropDownLine).length + ' Participating Jurisdictions' : stateNames[currentStateLine]}, {monthNames[Number(lookupPeriodStartMonthM)] + ' ' + lookupPeriodStartYearM + ' – ' + monthNames[Number(lookupPeriodEndMonthM)] + ' ' + lookupPeriodEndYearM}
           </h2>
           }
           {timelineLine == 'Annual' &&
           <h2 className="data-bite-header">
-            Suspected Nonfatal Overdose ED Visits per 10,000 Total ED Visits {selectedDrugsLine.length > 1 ? '' : ('Involving ' + drugOptions[selectedDrugsLine[0]].titleForDropDown)} in {currentStateLine == 'US' ? Object.keys(jurisForDropDownLine).length + ' Participating Jurisdictions' : stateNames[currentStateLine]}, {monthNames[Number(lookupPeriodStartMonthA)] + ' ' + lookupPeriodStartYearA + ' - ' + monthNames[Number(lookupPeriodEndMonthA)] + ' ' + lookupPeriodEndYearA}
+            Suspected Nonfatal Overdose ED Visits {selectedDrugsLine.length > 1 ? '' : ('Involving ' + drugOptions[selectedDrugsLine[0]].titleForDropDown)} per 10,000 Total ED Visits in {currentStateLine == 'US' ? Object.keys(jurisForDropDownLine).length + ' Participating Jurisdictions' : stateNames[currentStateLine]}, {monthNames[Number(lookupPeriodStartMonthA)] + ' ' + lookupPeriodStartYearA + ' – ' + monthNames[Number(lookupPeriodEndMonthA)] + ' ' + lookupPeriodEndYearA}
           </h2>
           }
         </div>
@@ -2188,12 +2189,12 @@ const getYears = (startYrInp, endYrInp) => {
         <div style={{'width':'100%', 'backgroundColor': drugOptions[hdrInfoFromMap].color}}>
           {mapMonthly == 'Monthly' &&
           <h2 className="data-bite-header">
-            Monthly Suspected Nonfatal Overdose ED Visits Involving {drugOptions[hdrInfoFromMap].titleForDropDown} per 10,000 Total ED Visits in {Object.keys(jurisForDropDownMap).length - 4} Participating Jurisdictions, {monthNames[Number(currentMonthMap)] + ' ' + currentYearMap}
+            Geographic distribution of Suspected Nonfatal Overdose ED Visits Involving {drugOptions[hdrInfoFromMap].titleForDropDown} per 10,000 Total ED Visits in {Object.keys(jurisForDropDownMap).length - 4} Participating Jurisdictions, {monthNames[Number(currentMonthMap)] + ' ' + currentYearMap}
           </h2>
           }
           {mapMonthly == 'Annual' &&
           <h2 className="data-bite-header">
-            Annual Suspected Nonfatal Overdose ED Visits Involving {drugOptions[hdrInfoFromMap].titleForDropDown} per 10,000 Total ED Visits in {Object.keys(jurisForDropDownMap).length - 4} Participating Jurisdictions, {UtilityFunctions.getPeriod(currentYearMap, currentMonthMap)}
+             Geographic distribution of Suspected Nonfatal Overdose ED Visits Involving {drugOptions[hdrInfoFromMap].titleForDropDown} per 10,000 Total ED Visits in {Object.keys(jurisForDropDownMap).length - 4} Participating Jurisdictions, {UtilityFunctions.getPeriod(currentYearMap, currentMonthMap)}
           </h2>
           }
         </div>
@@ -2255,7 +2256,29 @@ const getYears = (startYrInp, endYrInp) => {
                     </tr>
                   </table>
                 </td>
-                <td style={{'width': '28%'}}>
+                <td style={{'width': '10%'}}></td>
+                <td style={{'width': '18%'}}>
+                   <table>
+                    <tr>
+                      <td style={{ 'width' : '15%', 'textAlign': 'right'}}>
+                         <AngleArrow
+                            width={15}
+                            height={30}
+                            colorScale={'#000000'}
+                            defaultValueIfEmpty={defaultValueIfEmpty}
+                            percentValue={1}
+                          ></AngleArrow>
+                      </td>
+                      <td style={{ 'textAlign': 'right'}}>
+                          <svg style={{ height: 100, width: isSmallViewport ? width : 240, display: isSmallViewport ? 'block' : 'inline-block' }}>
+                            <text x={20} y={30} fill="black" alignmentBaseline="middle" fontSize={15} fontWeight={'bold'}>Want to know more?</text>
+                            <text x={20} y={50} fill="black" alignmentBaseline="middle" fontSize={15}>Hover over any state to </text>
+                            <text x={20} y={70} fill="black" alignmentBaseline="middle" fontSize={15}>see overdose-specific </text>
+                            <text x={20} y={90} fill="black" alignmentBaseline="middle" fontSize={15}>visits</text>
+                        </svg>
+                      </td>
+                    </tr>
+                  </table>
                 </td>
             </tr>
           </table>
@@ -2277,12 +2300,12 @@ const getYears = (startYrInp, endYrInp) => {
         <div style={{'width':'100%', 'backgroundColor': getHeaderColor(selectedDrugsSexAge)}}>
           {sexAgeMonthly == 'Monthly' &&
           <h2 className="data-bite-header">
-            Suspected Nonfatal Overdose ED Visits Involving {drugOptions[selectedDrugsSexAge[0]].titleAll} per 10,000 Total ED Visits by Sex, Age, and Sex by Age, in {jurisCountData[currentYearSexAge + String(currentMonthSexAge).padStart(2, '0') + sexAgeMonthly]} Participating Jurisdictions, {monthNames[Number(currentMonthSexAge)] + ' ' + currentYearSexAge}
+            Suspected Nonfatal Overdose ED Visits Involving {drugOptions[selectedDrugsSexAge[0]].titleAll} per 10,000 Total ED Visits by Sex, Age, and by Sex and Age, in {jurisCountData[currentYearSexAge + String(currentMonthSexAge).padStart(2, '0') + sexAgeMonthly]} Participating Jurisdictions, {monthNames[Number(currentMonthSexAge)] + ' ' + currentYearSexAge}
           </h2>
           }
           {sexAgeMonthly == 'Annual' &&
           <h2 className="data-bite-header">
-            Suspected Nonfatal Overdose ED Visits Involving {drugOptions[selectedDrugsSexAge[0]].titleAll} per 10,000 Total ED Visits by Sex, Age, and Sex by Age, in {jurisCountData[currentYearSexAge + String(currentMonthSexAge).padStart(2, '0') + sexAgeMonthly]} Participating Jurisdictions, {UtilityFunctions.getPeriod(currentYearSexAge, currentMonthSexAge)}
+            Suspected Nonfatal Overdose ED Visits Involving {drugOptions[selectedDrugsSexAge[0]].titleAll} per 10,000 Total ED Visits by Sex, Age, and by Sex and Age, in {jurisCountData[currentYearSexAge + String(currentMonthSexAge).padStart(2, '0') + sexAgeMonthly]} Participating Jurisdictions, {UtilityFunctions.getPeriod(currentYearSexAge, currentMonthSexAge)}
           </h2>
           }
         </div>
@@ -2428,6 +2451,7 @@ const getYears = (startYrInp, endYrInp) => {
             <div className="datatable-body">
              <p><strong>Important caveats to consider when interpreting the data include:</strong></p>
               <ol>
+                <li>We are excited to release the latest updates to this dashboard (effective June 2025). This iteration of the dashboard incorporates DOSE data from 2019 onward. Data from 2018 are excluded due to over 40% of jurisdictions reporting facility coverage below 70% [mean: 76.9%, median: 84.4%, range: 1.5%-100%]. Additionally, we have included facility coverage percentages supplied by the jurisdictions in the downloadable dataset for further clarity. Of the 47 jurisdictions who currently submit data to DOSE-SYS, 19 jurisdictions reported facility coverage less than 70% in 2018, and an additional 4 did not submit data to DOSE in 2018 (e.g., were not yet enrolled).</li>
                 <li>All data previously available on this dashboard (i.e., for the years 2018–2023) have been updated to reflect revisions in syndrome definitions. Datasets downloaded before March 2024 used older syndrome definitions, and data collected prior to August 2023 have been updated with the new syndrome definitions.</li>
                 <li><strong>Some data may be missing.</strong> Data sent from emergency departments (EDs) to health departments may be delayed or paused for a period of time.  Missing data are noted in footnotes, where applicable.</li>
                 <li>Nonfatal Drug Overdose Surveillance and Epidemiology – Syndromic Data (DOSE-SYS) Dashboard values <strong>may differ from data accessible through the National Syndromic Surveillance Program (NSSP) BioSense Platform.</strong> Many jurisdictions extract data from NSSP’s Electronic Surveillance System for the Early Notification of Community-based Epidemics (ESSENCE) database as part of their data submission process. However, DOSE-SYS data may differ from NSSP ESSENCE data due to differences in jurisdiction data preparation as well as the dynamic nature of NSSP’s progressively updating data.</li>

--- a/src/components/LineChart.js
+++ b/src/components/LineChart.js
@@ -620,11 +620,13 @@ const adjustCrowdedLabels = () => {
             return <rect
               key={`tooltip-section-${d[specs.xKey]}`}
               fill={UtilityFunctions.isCovidPeriod(d['year'])  ? '#E7E7E7' : 'transparent'}
+              strokeWidth={UtilityFunctions.isCovidPeriod(d['year'])  ? 3 : null}
+              stroke={UtilityFunctions.isCovidPeriod(d['year'])  ? '#E7E7E7' : null}
               x={Math.max(0, specs.xScale(d[specs.xKey]) - sectionWidthHalf)}
               y={0}
               width={(UtilityFunctions.doesEndWithCovidPeriod(inp.filteredData, 'US') && (index == (inp.filteredData['US'].length - 1))) ? (sectionWidth/2) : (sectionWidth)}
               height={specs.yMax}
-              style={{outline: 'none'}}
+              style={{outline: 'none', shapeRendering: UtilityFunctions.doesEndWithCovidPeriod(inp.filteredData, 'US') ? 'crispEdges' : ''}}
               data-tip={getDataTip(d, tooltipValuesSorted)}></rect>
           })
         }

--- a/src/components/UsaMap.js
+++ b/src/components/UsaMap.js
@@ -6,7 +6,6 @@ import { CustomProjection } from '@visx/geo';
 import { scaleLinear } from '@visx/scale';
 import ReactTooltip from 'react-tooltip';
 import { geoAlbersUsaTerritories } from 'd3-composite-projections';
-import AngleArrow from './AngleArrow';
 import { UtilityFunctions } from '../utility'
 
 const { features: stateTopoPre2020 } = feature(topoJSONPre2020, topoJSONPre2020.objects.states)
@@ -156,7 +155,7 @@ const UsaMap = (params) => {
   let colorIntervals = [];
   for (let i = 0; i < 5; i++) {
     let val = i == 0 ? max : (max - (intervalWidth) * (i))
-    labelIntervals.push( i != 4 ? (String(Number(val < 0 ? 0.0001 : val).toFixed(1)) + ' - '  + String((Number(val < 0 ? 0.0001 : val) - intervalWidth).toFixed(1))) : (String(Number(val < 0 ? 0.0001 : val).toFixed(1)) + ' - 0.0'))
+    labelIntervals.push( i != 4 ? (String((Number(val < 0 ? 0.0001 : val) - intervalWidth).toFixed(1) + ' - ' + String(Number(val < 0 ? 0.0001 : val).toFixed(1)))) : ('0.0 - ' + String(Number(val < 0 ? 0.0001 : val).toFixed(1))))
     colorIntervals.push(Number(val < 0 ? 0.0001 : val).toFixed(1))
   }
 
@@ -293,31 +292,6 @@ const UsaMap = (params) => {
           </td>
           <td style={{width: '21%'}}>
             <table>
-              <tr>
-                <td>
-                  <table>
-                    <tr>
-                      <td style={{ 'width' : '15%'}}>
-                         <AngleArrow
-                            width={15}
-                            height={30}
-                            colorScale={'#000000'}
-                            defaultValueIfEmpty={defaultValueIfEmpty}
-                            percentValue={1}
-                          ></AngleArrow>
-                      </td>
-                      <td>
-                          <svg style={{ height: 100, width: isSmallViewport ? width : legendWidth, display: isSmallViewport ? 'block' : 'inline-block' }}>
-                            <text x={20} y={30} fill="black" alignmentBaseline="middle" fontSize={fontSize} fontWeight={'bold'}>Want to know more?</text>
-                            <text x={20} y={50} fill="black" alignmentBaseline="middle" fontSize={fontSize}>Hover over any state to </text>
-                            <text x={20} y={70} fill="black" alignmentBaseline="middle" fontSize={fontSize}>see overdose-specific </text>
-                            <text x={20} y={90} fill="black" alignmentBaseline="middle" fontSize={fontSize}>visits</text>
-                        </svg>
-                      </td>
-                    </tr>
-                  </table>
-                </td>
-              </tr>
               <br></br>
               <tr>
                 <td style={{'border':'solid 2px gray', 'padding':'10px', 'borderRadius': '10px'}}>

--- a/src/utility.js
+++ b/src/utility.js
@@ -588,7 +588,7 @@ export const UtilityFunctions = {
 
     let d = new Date(currentYear + '/' + currentMonth + '/' + '01');
     d.setMonth(d.getMonth() - 11);
-    return d.toLocaleString('default', { month: 'short' }) + ' ' + d.getFullYear() + ' - ' + monthNames[Number(currentMonth)].substring(0,3) + ' ' + currentYear; 
+    return d.toLocaleString('default', { month: 'short' }) + ' ' + d.getFullYear() + ' – ' + monthNames[Number(currentMonth)].substring(0,3) + ' ' + currentYear; 
   },
 
   isCovidPeriod : (yearmon) => {


### PR DESCRIPTION
UAT Findings:

IDEA-S 0.0:  Wherever there is a hyphen (-) between date ranges, it should be replaced with an en dash (–).
IDEA-S 6.0: When we click on the annual button in the figure below this box, it causes the left box to change from saying “monthly” to “annual”—no data value changes; I believe this is an error and that these boxes aren’t supposed to change with any of the interactive buttons. 
IDEA-S 10.2: Remove white outlines from box for COVID-19
IDEA-S 11.3:  Change the order of the legend ranges to be from low values to high values, i.e. “0-45.5, 45.5-58.3…84.0-96.9”.
IDEA-S 11.3: Improve spacing by moving the “Want to know more” graphic in line with time period selection 
IDEA-S 17.0: Add the text below as point 1. of Important Data Considerations and reorder remaining numbers:
We are excited to release the latest updates to this dashboard (effective June 2025). This iteration of the dashboard incorporates DOSE data from 2019 onward. Data from 2018 are excluded due to over 40% of jurisdictions reporting facility coverage below 70% [mean: 76.9%, median: 84.4%, range: 1.5%-100%]. Additionally, we have included facility coverage percentages supplied by the jurisdictions in the downloadable dataset for further clarity. Of the 47 jurisdictions who currently submit data to DOSE-SYS, 19 jurisdictions reported facility coverage less than 70% in 2018, and an additional 4 did not submit data to DOSE in 2018 (e.g., were not yet enrolled).  
IDEA-S 21.0:  Please change the footnote after 47 Jurisdictions Participating from [5] to [1]
IDEA-S 31: Reword trend plot title [REWORK] - note: the order of the wording was a little off on this one. The drug indicator should be before "per 10,000 ED visits. It should read: "Suspected Nonfatal Overdose ED Visits Involving [drug type] per 10,000 Total ED Visits in [#] Participating Jurisdictions, [Time frame]"
IDEA-S 32.0: Change header to “Geographic distribution of Suspected Nonfatal Overdose ED Visits Involving All Drugs per 10,000 Total ED Visits in [#] Participating Jurisdictions, [Time Frame]”
IDEA-S 33.0: Change title to “Suspected Nonfatal Overdose ED Visits Involving All Drugs per 10,000 Total ED Visits by Sex, Age, and by Sex and Age, in [#] Participating Jurisdictions [timeframe]

Thanks.

