### PR TITLE
Sravan dose surveillance 07282025 2000

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1519,7 +1519,7 @@ const getYears = (startYrInp, endYrInp) => {
               </tr>
               <tr style={{ textAlign: 'left', fontSize: '15px'}}>
                 <td style={{ width: '10%' }}></td>
-                <td style={{ width: '95%' }}><small><i><sup>**</sup>{'Data not available/not reported'}</i></small></td>
+                <td style={{ width: '95%' }}><small><i><sup>†</sup>{'Data not available/not reported'}</i></small></td>
               </tr>
             </table>
           </div>
@@ -2038,9 +2038,9 @@ const getYears = (startYrInp, endYrInp) => {
             <td style={{width: '15%'}}></td>
             <td style={{width: '80%'}}>
               <div><span><small><i><sup>*</sup>Data suppressed.</i></small></span></div>
-              <div><span><small><i><sup>**</sup>Data not available/not reported.</i></small></span></div>
-              <div><span><small><i><sup>†</sup>Scale of the figure may change based on the data presented.</i></small></span></div>
-              <div><span><small><i><sup>§</sup>These categories are not mutually exclusive and reflect nesting. Some overdose visits may involve multiple substances.</i></small></span></div>
+              <div><span><small><i><sup>†</sup>Data not available/not reported.</i></small></span></div>
+              <div><span><small><i><sup>§</sup>Scale of the figure may change based on the data presented.</i></small></span></div>
+              <div><span><small><i><sup>¶</sup>These categories are not mutually exclusive and reflect nesting. Some overdose visits may involve multiple substances.</i></small></span></div>
             </td>
             <td style={{width: '5%'}}></td>
           </tr>
@@ -2062,7 +2062,7 @@ const getYears = (startYrInp, endYrInp) => {
         </div>
         <table>
              <tr>
-              <td style={{'width': '16.8%', 'textAlign': 'left', 'verticalAlign': 'top', 'fontWeight': 'bold'}}><div className="select-input">Select Time Period:<sup>**</sup></div></td>
+              <td style={{'width': '16.8%', 'textAlign': 'left', 'verticalAlign': 'top', 'fontWeight': 'bold'}}><div className="select-input">Select Time Period:</div></td>
               <td style={{'width': '84%'}}>
                 { !showAnnualLine &&
                   <div style={wrapperStyle}>
@@ -2185,7 +2185,18 @@ const getYears = (startYrInp, endYrInp) => {
             </tr>
           </table>
           <br></br>
-
+          {
+            currentStateLine == 'IL' && (selectedDrugsLine.includes('fentanyl') || selectedDrugsLine.includes('heroin')) &&
+             <table>
+              <tr>
+                <td style={{'textAlign': 'center'}}>
+                  <strong>Note: </strong><span>Fentanyl and Heroin data are not available / not reported for Illinois.</span>
+                </td>
+              </tr>
+              <br></br>
+            </table>
+            
+          }
           {lineChartMemo}
           <br></br>
           <table style={{width: '100%'}}>
@@ -2193,11 +2204,12 @@ const getYears = (startYrInp, endYrInp) => {
               <td style={{width: '5%'}}></td>
               <td style={{width: '80%'}}>
                 <div><span><small><i><sup>*</sup>Data suppressed.</i></small></span></div>
-                <div><span><small><i><sup>†</sup>Scale of the figure may change based on the data presented.</i></small></span></div>
-                 <div><span><small><i><sup>§</sup>Monthly comparisons should be interpreted with caution due to seasonality, with common increases in nonfatal drug overdoses in summer and decreases in winter<sup>2</sup>.</i></small></span></div>
+                <div><span><small><i><sup>†</sup>Data not available/not reported.</i></small></span></div>
+                <div><span><small><i><sup>§</sup>Scale of the figure may change based on the data presented.</i></small></span></div>
+                 <div><span><small><i><sup>¶</sup>Monthly comparisons should be interpreted with caution due to seasonality, with common increases in nonfatal drug overdoses in summer and decreases in winter<sup>2</sup>.</i></small></span></div>
                 {((timelineLine == 'Monthly' && UtilityFunctions.containsCovidPeriod(lookupPeriodStartYearM, lookupPeriodStartMonthM, lookupPeriodEndYearM, lookupPeriodEndMonthM)) ||
                  (timelineLine == 'Annual' && UtilityFunctions.containsCovidPeriod(lookupPeriodStartYearA, lookupPeriodStartMonthA, lookupPeriodEndYearA, lookupPeriodEndMonthA))) &&
-                  <div><span><small><i><sup>¶</sup>Grayed out area represents the COVID-19 pandemic and is distinct from data suppression.</i></small></span></div>
+                  <div><span><small><i><sup>‡</sup>Grayed out area represents the COVID-19 pandemic and is distinct from data suppression.</i></small></span></div>
                 }
               </td>
               <td style={{width: '15%'}}></td>

--- a/src/App.js
+++ b/src/App.js
@@ -2215,7 +2215,6 @@ const getYears = (startYrInp, endYrInp) => {
               <td style={{width: '15%'}}></td>
             </tr>
           </table>
-
       </section>
 
       <section>

--- a/src/components/BarChart.js
+++ b/src/components/BarChart.js
@@ -209,7 +209,7 @@ function BarChart(params) {
                         dy="22"
                         dx={"0"}
                         fill="black"
-                        data-tip={`<strong>${drugOptions[stateKey].titleAll}</strong><br/><br/>Rate: Data Not Available/Not Reported`}>**
+                        data-tip={`<strong>${drugOptions[stateKey].titleAll}</strong><br/><br/>Rate: Data Not Available/Not Reported`}>†
                         </text>
                     }
                     {

--- a/src/components/LineChart.js
+++ b/src/components/LineChart.js
@@ -209,7 +209,8 @@ function LineChart(params) {
     filteredData['US'] = isPeriod ? getFilteredDataPeriod(dataOverall, 'US', lookupPeriodStartYear, lookupPeriodStartMonth, lookupPeriodEndYear, lookupPeriodEndMonth) : getFilteredData(dataOverall, 'US', String(lookupPeriodStartYear), String(lookupPeriodEndYear))
   }
 
-  const yScaleDomainPeriod = (UtilityFunctions.calculateYScaleDomain(filteredData, currentDrug, selectedDrugs, currentState, showOverall) * 1.2);
+  const tmpyScaleDomainPeriod = UtilityFunctions.calculateYScaleDomain(filteredData, currentDrug, selectedDrugs, currentState, showOverall);
+  const yScaleDomainPeriod = (tmpyScaleDomainPeriod == -1 ? 1 : (tmpyScaleDomainPeriod * 1.2));
 
   useEffect(() => {
     markYearsForTicks();
@@ -526,7 +527,7 @@ const adjustCrowdedLabels = () => {
     let str = `<table class='tooltipTableLC'><tr><td><span class='toolTipSpanLC'><strong>`
     let stStr = inp.currentTimeframe === 'Monthly' ? `${inp.monthNamesPeriod[d[[specs.xKey]]]}` : UtilityFunctions.getPeriod(d['year'].substring(0,4), d['year'].substring(4));
     let msgStr = inp.currentTimeframe === 'Monthly' ? '' : `&nbsp<span class='smallFont alignCenter'>12-month rolling averages starting and ending period</span>`;
-    let midStr = `<p><strong class=${inp.selectedDrugs[0] + 'ToolTip'}>` + drugOptions[inp.selectedDrugs[0]].titleForDropDown + `</strong>: ${rate == 0 ? 'Data Suppressed' : rate}</p>`
+    let midStr = `<p><strong class=${inp.selectedDrugs[0] + 'ToolTip'}>` + drugOptions[inp.selectedDrugs[0]].titleForDropDown + `</strong>: ${rate == 0 ? 'Data Suppressed' : (rate == '-1.0' ? 'Data not available/not reported' : rate)}</p>`
     let parStr = `</strong></span>` + midStr + `</td></tr></table>`;
     return str + stStr + `</td></tr><tr><td class='alignCenter'>` + msgStr + parStr;
   }
@@ -538,8 +539,8 @@ const adjustCrowdedLabels = () => {
     let str = `<table class='tooltipTableLC'><tr><td><span class='toolTipSpanLC'><strong>`
     let stStr = inp.currentTimeframe === 'Monthly' ? `${inp.monthNamesPeriod[d[[specs.xKey]]]}` : UtilityFunctions.getPeriod(d['year'].substring(0,4), d['year'].substring(4));
     let msgStr = inp.currentTimeframe === 'Monthly' ? '' : `&nbsp<span class='smallFont alignCenter'>12-month rolling averages starting and ending period</span>`;
-    let midStr1 = `<p class='alignLeft'><strong class=${inp.selectedDrugs[0] + 'ToolTip'}>` + 'Overall' + `</strong>: ${rateSt == 0 ? 'Data Suppressed' : rateUS} (${getJurisCount(d['year'])} Jurisdictions)</p>`
-    let midStr2 = `<p class='alignLeft'><strong class=${inp.selectedDrugs[0] + 'ToolTip'}>` + drugOptions[inp.selectedDrugs[0]].titleForDropDown + `</strong>: ${rateSt == 0 ? 'Data Suppressed' : rateSt}</p>`
+    let midStr1 = `<p class='alignLeft'><strong class=${inp.selectedDrugs[0] + 'ToolTip'}>` + 'Overall' + `</strong>: ${rateUS == 0 ? 'Data Suppressed' : (rateUS == '-1.0' ? 'Data not available/not reported' : rateUS)} (${getJurisCount(d['year'])} Jurisdictions)</p>`
+    let midStr2 = `<p class='alignLeft'><strong class=${inp.selectedDrugs[0] + 'ToolTip'}>` + drugOptions[inp.selectedDrugs[0]].titleForDropDown + `</strong>: ${rateSt == 0 ? 'Data Suppressed' : (rateSt == '-1.0' ? 'Data not available/not reported' : rateSt)}</p>`
     let parStr = `</strong></span>` + midStr1 + midStr2 + `</td></tr></table>`;
     return str + stStr + `</td></tr><tr><td class='alignCenter'>` + msgStr + parStr;
   }
@@ -621,7 +622,7 @@ const adjustCrowdedLabels = () => {
               var tooltipValues = [];
               if (inp.selectedDrugs.length > 0) {
                   for (var i in inp.selectedDrugs) {
-                      tooltipValues.push(`<div class='toolTipPad'><span><strong class=${inp.selectedDrugs[i] + 'ToolTip'}>` + drugOptions[inp.selectedDrugs[i]].titleForDropDown + `</strong>: ${d[inp.selectedDrugs[i]] == 0 ? 'Data Suppressed' : d[inp.selectedDrugs[i]]}</span></div>`);
+                      tooltipValues.push(`<div class='toolTipPad'><span><strong class=${inp.selectedDrugs[i] + 'ToolTip'}>` + drugOptions[inp.selectedDrugs[i]].titleForDropDown + `</strong>: ${d[inp.selectedDrugs[i]] == 0 ? 'Data Suppressed' : (d[inp.selectedDrugs[i]] == '-1.0' ? 'Data not available/not reported' : d[inp.selectedDrugs[i]])}</span></div>`);
                     }
                   }
               }
@@ -708,8 +709,8 @@ const adjustCrowdedLabels = () => {
 
     const seriesLabelPositionUS = endWithCovidPeriod && !allPeriodIsCovid ? specs.yScale(inp.filteredData['US'][inp.filteredData['US'].length - 1 - covidTimeIndex][currentDrug]) : specs.yScale(inp.filteredData['US'][inp.filteredData['US'].length - 1][currentDrug]);
     const valueState = inp.filteredData[inp.currentState].length > 0 ? (endWithCovidPeriod && !allPeriodIsCovid ? inp.filteredData[inp.currentState][inp.filteredData[inp.currentState].length - 1 - covidTimeIndex][currentDrug] : inp.filteredData[inp.currentState][inp.filteredData[inp.currentState].length - 1][currentDrug]) : 'Data suppressed*';
-    const seriesLabelPositionState = valueState === 'Data suppressed*' ? specs.yScale(0) - 30 : specs.yScale(valueState);
-    
+    const seriesLabelPositionState = (valueState === 'Data suppressed*' || valueState === '-1.0') ? specs.yScale(0) - 15 : specs.yScale(valueState);
+
     if (seriesLabelPositionUS === undefined)
       return;
     
@@ -737,6 +738,7 @@ const adjustCrowdedLabels = () => {
                           {(!isNaN(d[currentDrug]) && key != 'US') && <text x={i == 0 ? specs.xScale(d[specs.xKey]) :  specs.xScale(d[specs.xKey])} y={specs.yScale(d[currentDrug])-8} stroke={'lightblue'} fill={'lightblue'} fontSize={12} textAnchor={i == 0 ? 'right' : 'middle'}>{showLabels ? d[currentDrug] : ''}</text>}
                           {(!isNaN(d[currentDrug]) && key != 'US') && d[currentDrug] > 0 && <Circle cx={specs.xScale(d[specs.xKey])} cy={specs.yScale(d[currentDrug])} r={4} fill={UtilityFunctions.getSeriesColorLine(currentDrug, key, showOverall)} />}
                           {(!isNaN(d[currentDrug]) && key != 'US') && d[currentDrug] == 0 && <text x={i == 0 ? specs.xScale(d[specs.xKey]) :  specs.xScale(d[specs.xKey])} y={specs.yScale(d[currentDrug])-8} stroke={''} fill={UtilityFunctions.getSeriesColorLine(currentDrug, key, showOverall)} fontSize={16} fontWeight={'bold'} textAnchor={i == 0 ? 'right' : 'middle'}>{!UtilityFunctions.isCovidPeriod(d['year']) ? '*' : ''}</text>}
+                          {(!isNaN(d[currentDrug]) && key != 'US') && d[currentDrug] == '-1.0' && <text x={i == 0 ? specs.xScale(d[specs.xKey]) :  specs.xScale(d[specs.xKey])} y={specs.yScale(0)-8} stroke={''} fill={UtilityFunctions.getSeriesColorLine(currentDrug, key, showOverall)} fontSize={16} fontWeight={'bold'} textAnchor={i == 0 ? 'right' : 'middle'}>{!UtilityFunctions.isCovidPeriod(d['year']) ? '†' : ''}</text>}
                         </Group>
                         )
                     })}

--- a/src/components/StateChart.js
+++ b/src/components/StateChart.js
@@ -276,7 +276,7 @@ function StateChart(params) {
                         dy="16"
                         dx="0"
                         data-tip={`<strong>${name}</strong><br/><br/>Rate: Data Not Available/Not Reported`}>
-                        {'**'}
+                        {'†'}
                       </text>
                     }
                     


### PR DESCRIPTION
- Change 1: [High priority] Add the note below the drug syndrome selection box to Illinois trend figure when Fentanyl or Heroin are selected (a pop out text object similar to one we did for Annual data)
- Change 2: [High priority]: Correct axes that are negative values (IL fentanyl/heroin).
- Change 3: [High priority]: Remove the double asterisk (**) by Select Time Period in the trend plot
- Change 4a: [Medium priority]: Add updated footnote for other missing data in trend figure: Where data is coded as 8888 (ex: Michigan Jan-Feb 2019 and May-June 2024; Idaho Jan-June 2019; Wisconsin Jan-Feb 2019; list may not be exhaustive), add the footnote below and update the figure to show the symbol below for all data points where the data was not available/not reported.
- Change 4b: [Medium priority]: Update text box when we hover over the figure when there is other missing data in trend figure: Instead of –1.0, it should say “Data not available / not reported” when you hover over the figure. This should be true for all instances above in 4a, including Illinois.
- Change 5: [Medium priority] In the state bar plot, drug breakdown bar plot, and trend plot, replace double asterisk (**) footnote and replace it with the next footnote in the series: *, †, §, ¶, ‡, &

Thanks.