### PR TITLE
Sravan dose discharge 08112025 0800

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -160,7 +160,7 @@ const createIfUndefined = (object, key, value) => {
 const formatNumber = (val, isFloat = true) => {
   let numericVal = isFloat ? parseFloat(val) : parseInt(val);
   if (isNaN(numericVal)) {
-    if (val == 'not available' || val == 'NA')
+    if (val == 'NA')
       return 'Data not available';
     return 'Data suppressed*';
   } else {
@@ -851,12 +851,25 @@ export default function App(params) {
     setStateDropdownOptions(Object.keys(supportedStates))
   }
 
+  function isStateInSupportedStates(ds, yr, mon, tframe) {
+    let monMain = tframe != 'Monthly' ? '00' : String(mon).padStart(2, '0');
+    let key = ds + '_' + yr + monMain;
+
+    let strStates = data.supportedJurisdictions[key]?.split(',');
+    return strStates.includes(currentState);
+  }
+
   const handleTabClick = (index) => {
     let ds;
     setActiveTab(index);
     ds = index == 0 ? 'ED' : 'HOSP';
     setCurrentDataSource(ds)
     getSupportedStates(ds, currentYear, currentMonth, currentTimeframe);
+
+    if (!isStateInSupportedStates(ds, currentYear, currentMonth, currentTimeframe)){
+      setCurrentState('US');
+      setOnlyCurrentDrug(false);
+    }
   };
 
   const stateBarChartMemo = useMemo(() =>
@@ -1001,6 +1014,11 @@ export default function App(params) {
                     }
 
                     setPeriodToggle(false);
+
+                    if (!isStateInSupportedStates(currentDataSource, currentYear, currentMonth, val)){
+                      setCurrentState('US');
+                      setOnlyCurrentDrug(false);
+                    }
                   },
                   options: ['Monthly', 'Annual'],
                   optionLabel: (key) => key
@@ -1025,6 +1043,11 @@ export default function App(params) {
                     if (currentTimeframe === 'Monthly') {
                       resetPeriodDates(param)
                     }
+
+                    if (!isStateInSupportedStates(currentDataSource, param, currentMonth, currentTimeframe)){
+                      setCurrentState('US');
+                      setOnlyCurrentDrug(false);
+                    }
                   },
                   options: supportedYears,
                   optionLabel: (key) => key
@@ -1038,6 +1061,11 @@ export default function App(params) {
                     getSupportedStates(currentDataSource, currentYear, param, currentTimeframe);
                     resetPeriodDates(currentYear);
                     setPeriodToggle(false);
+
+                    if (!isStateInSupportedStates(currentDataSource, currentYear, param, currentTimeframe)) {
+                      setCurrentState('US');
+                      setOnlyCurrentDrug(false);
+                    }
                   },
                   options: Object.keys(monthNames).filter(key => key !== 'all'),
                   optionLabel: (key) => monthNames[key],
@@ -1133,22 +1161,21 @@ export default function App(params) {
             <section className="first-section">
               {lineChartMemo}
               <br></br>
-              {accessible && getFootNotesForData()}
+              {!accessible && getFootNotesForData()}
             </section>
 
             <section>
               {stateBarChartMemo}
-              {accessible && getFootNotesForData()}
+              {!accessible && getFootNotesForData()}
             </section>
 
             <section>
               {sexAgeChartsMemo}
-              {accessible && getFootNotesForData()}
+              {!accessible && getFootNotesForData()}
             </section>
 
             <section>
               {usaMapMemo}
-              {(accessible && currentDataSource === 'ED' && currentDrug === 'alldrug') && getFootNotesForData()}
             </section>
           </>
         )}

--- a/src/App.js
+++ b/src/App.js
@@ -851,14 +851,6 @@ export default function App(params) {
     setStateDropdownOptions(Object.keys(supportedStates))
   }
 
-  function isStateInSupportedStates(ds, yr, mon, tframe) {
-    let monMain = tframe != 'Monthly' ? '00' : String(mon).padStart(2, '0');
-    let key = ds + '_' + yr + monMain;
-
-    let strStates = data.supportedJurisdictions[key]?.split(',');
-    return strStates.includes(currentState);
-  }
-
   const handleTabClick = (index) => {
     let ds;
     setActiveTab(index);
@@ -866,7 +858,7 @@ export default function App(params) {
     setCurrentDataSource(ds)
     getSupportedStates(ds, currentYear, currentMonth, currentTimeframe);
 
-    if (!isStateInSupportedStates(ds, currentYear, currentMonth, currentTimeframe)){
+    if (!UtilityFunctions.isStateInSupportedStates(data.supportedJurisdictions, ds, currentYear, currentMonth, currentTimeframe, currentState)){
       setCurrentState('US');
       setOnlyCurrentDrug(false);
     }
@@ -1015,7 +1007,7 @@ export default function App(params) {
 
                     setPeriodToggle(false);
 
-                    if (!isStateInSupportedStates(currentDataSource, currentYear, currentMonth, val)){
+                    if (!UtilityFunctions.isStateInSupportedStates(data.supportedJurisdictions, currentDataSource, currentYear, currentMonth, val, currentState)){
                       setCurrentState('US');
                       setOnlyCurrentDrug(false);
                     }
@@ -1044,7 +1036,7 @@ export default function App(params) {
                       resetPeriodDates(param)
                     }
 
-                    if (!isStateInSupportedStates(currentDataSource, param, currentMonth, currentTimeframe)){
+                    if (!UtilityFunctions.isStateInSupportedStates(data.supportedJurisdictions, currentDataSource, param, currentMonth, currentTimeframe, currentState)){
                       setCurrentState('US');
                       setOnlyCurrentDrug(false);
                     }
@@ -1062,7 +1054,7 @@ export default function App(params) {
                     resetPeriodDates(currentYear);
                     setPeriodToggle(false);
 
-                    if (!isStateInSupportedStates(currentDataSource, currentYear, param, currentTimeframe)) {
+                    if (!UtilityFunctions.isStateInSupportedStates(data.supportedJurisdictions, currentDataSource, currentYear, param, currentTimeframe, currentState)) {
                       setCurrentState('US');
                       setOnlyCurrentDrug(false);
                     }

--- a/src/accessibility.js
+++ b/src/accessibility.js
@@ -94,49 +94,97 @@ export const AccessibilityFunctions = {
           let obj = {};
           if (currentDrug == 'alldrug') {
             obj['Overall'] = data['US'][i].alldrug;
-            obj[stateNames[state]] = data[state][i].alldrug;
+             obj[stateNames[state]] = '';
+            for (var j=0;j<Object.keys(data[state]).length;j++)
+            {
+              if (data['US'][i].year == data[state][j].year) {
+                obj[stateNames[state]] = data[state][j].alldrug;
+              }
+            }
           }
 
           if (currentDrug == 'benzodiazepine') {
-             obj['Overall'] = data['US'][i].benzodiazepine;
-            obj[stateNames[state]] = data[state][i].benzodiazepine;
+            obj['Overall'] = data['US'][i].benzodiazepine;
+            obj[stateNames[state]] = '';
+              for (var j=0;j<Object.keys(data[state]).length;j++)
+              {
+                if (data['US'][i].year == data[state][j].year) {
+                  obj[stateNames[state]] = data[state][j].benzodiazepine;
+                }
+              }
           }
 
           if (currentDrug == 'cocaine') {
             obj['Overall'] = data['US'][i].cocaine;
-            obj[stateNames[state]] = data[state][i].cocaine;
+             obj[stateNames[state]] = '';
+              for (var j=0;j<Object.keys(data[state]).length;j++)
+              {
+                if (data['US'][i].year == data[state][j].year) {
+                  obj[stateNames[state]] = data[state][j].cocaine;
+                }
+              }
           }
 
           if (currentDrug == 'fentanyl') {
              obj['Overall'] = data['US'][i].fentanyl;
-            obj[stateNames[state]] = data[state][i].fentanyl;
+              obj[stateNames[state]] = '';
+              for (var j=0;j<Object.keys(data[state]).length;j++)
+              {
+                if (data['US'][i].year == data[state][j].year) {
+                  obj[stateNames[state]] = data[state][j].fentanyl;
+                }
+              }
           }
 
           if (currentDrug == 'heroin') {
              obj['Overall'] = data['US'][i].heroin;
-            obj[stateNames[state]] = data[state][i].heroin;
+              obj[stateNames[state]] = '';
+              for (var j=0;j<Object.keys(data[state]).length;j++)
+              {
+                if (data['US'][i].year == data[state][j].year) {
+                  obj[stateNames[state]] = data[state][j].heroin;
+                }
+              }
           }
 
           if (currentDrug == 'methamphetamine') {
             obj['Overall'] = data['US'][i].methamphetamine;
-            obj[stateNames[state]] = data[state][i].methamphetamine;
+            obj[stateNames[state]] = '';
+              for (var j=0;j<Object.keys(data[state]).length;j++)
+              {
+                if (data['US'][i].year == data[state][j].year) {
+                  obj[stateNames[state]] = data[state][j].methamphetamine;
+                }
+              }
           }
 
           if (currentDrug == 'opioid') {
              obj['Overall'] = data['US'][i].opioid;
-            obj[stateNames[state]] = data[state][i].opioid;
+              obj[stateNames[state]] = '';
+              for (var j=0;j<Object.keys(data[state]).length;j++)
+              {
+                if (data['US'][i].year == data[state][j].year) {
+                  obj[stateNames[state]] = data[state][j].opioid;
+                }
+              }
           }
 
           if (currentDrug == 'stimulant') {
              obj['Overall'] = data['US'][i].stimulant;
-            obj[stateNames[state]] = data[state][i].stimulant;
+              obj[stateNames[state]] = '';
+              for (var j=0;j<Object.keys(data[state]).length;j++)
+              {
+                if (data['US'][i].year == data[state][j].year) {
+                  obj[stateNames[state]] = data[state][j].stimulant;
+                }
+              }
           }
 
           let monyr = data['US'][i].year;
           myData[monyr] = obj;
         }
       }
-
+            
       return myData;
   
     },  

--- a/src/components/DataTable508.js
+++ b/src/components/DataTable508.js
@@ -62,10 +62,10 @@ function DataTable508(params) {
     var ret = val;
 
     if (String(val).indexOf('Data suppressed') >= 0)
-      ret = '*';
+      ret = 'Data suppressed';
 
     if (String(val).indexOf('Data not available') >= 0)
-      ret = '†';
+      ret = 'Data not available/not reported';
 
     return ret;
   }

--- a/src/components/LineChart.js
+++ b/src/components/LineChart.js
@@ -44,15 +44,19 @@ const getCountsYearly = (data, currentDataSource, drugOptions) => {
     Object.keys(data[currentDataSource][drug]).forEach(year => {
       if (!isNaN(year)) {
         var cnt = 0;
+        var cntText = '';
         Object.keys(data[currentDataSource][drug][year]['all']['count']).forEach(rec => {
-          var femCnt = isNaN(data[currentDataSource][drug][year]['all']['count'][rec]['F']) ? 0 : Number(data[currentDataSource][drug][year]['all']['count'][rec]['F']);
-          var maleCnt = isNaN(data[currentDataSource][drug][year]['all']['count'][rec]['M']) ? 0 : Number(data[currentDataSource][drug][year]['all']['count'][rec]['M']);
-          cnt = Number(cnt) + Number(femCnt) + Number(maleCnt);
+          var femCnt = data[currentDataSource][drug][year]['all']['count'][rec]['F'];
+          var maleCnt = data[currentDataSource][drug][year]['all']['count'][rec]['M'];
+
+          cnt = Number(cnt) + (isNaN(femCnt) ? 0 : Number(femCnt)) + (isNaN(maleCnt) ? 0 : Number(maleCnt));
+            if (isNaN(femCnt) && isNaN(maleCnt))
+              cntText = femCnt;
         })
         arr.push({
           year: year,
           drug: drug,
-          count: cnt,
+          count: ((cnt == 0 && cntText.length > 0) ? cntText : cnt),
         });
       }
     })
@@ -69,16 +73,19 @@ const getCountsMonthly = (data, currentDataSource, drugOptions) => {
         for (var mon=1;mon<=12;mon++)
         {
           var cnt = 0;
+          var cntText = '';
           Object.keys(data[currentDataSource][drug][year][mon]['count']).forEach(rec => {
-            var femCnt = isNaN(data[currentDataSource][drug][year][mon]['count'][rec]['F']) ? 0 : Number(data[currentDataSource][drug][year][mon]['count'][rec]['F']);
-            var maleCnt = isNaN(data[currentDataSource][drug][year][mon]['count'][rec]['M']) ? 0 : Number(data[currentDataSource][drug][year][mon]['count'][rec]['M']);
-            cnt = Number(cnt) + Number(femCnt) + Number(maleCnt);
+            var femCnt = data[currentDataSource][drug][year][mon]['count'][rec]['F'];
+            var maleCnt = data[currentDataSource][drug][year][mon]['count'][rec]['M'];
+            cnt = Number(cnt) + (isNaN(femCnt) ? 0 : Number(femCnt)) + (isNaN(maleCnt) ? 0 : Number(maleCnt));
+            if (isNaN(femCnt) && isNaN(maleCnt))
+              cntText = femCnt;
           })
           arr.push({
             year: year,
             month: mon,
             drug: drug,
-            count: cnt,
+            count: ((cnt == 0 && cntText.length > 0) ? cntText : cnt),
           });
         }
       }
@@ -614,19 +621,28 @@ function LineChart({ params }) {
     return cnt;
   }
 
+  const getText = (val) => {
+    if (val == 'Data not available')
+      return 'Data not available/not reported';
+    else if (val == 'Data suppressed*')
+      return 'Data suppressed';
+    else
+      return '';
+  }
+
   const getRateHTMLforDrug = (selectedDrugs, parmState, val) => {
     var leftRateStr = '';
     if (parmState == 'US') {
       for (var i in selectedDrugs) {
         if (selectedDrugs[i].includes(currentDrug)) {
           let rate = getRateforDrug(selectedDrugs[i], parmState, val);
-          leftRateStr = leftRateStr + `<span class=${selectedDrugs[i] + 'ToolTip'}` + '>' + (isNaN(rate) ? 0 : rate) + '</span></br>'
+          leftRateStr = leftRateStr + `<span class=${selectedDrugs[i] + 'ToolTip'}` + '>' + (isNaN(rate) ? getText(rate) : rate) + '</span></br>'
         }
       }
     }
     else {
       let rate = getRateforDrug(currentDrug, parmState, val);
-        leftRateStr = leftRateStr + `<span class=${currentDrug + 'ToolTip'}` + '>' + (isNaN(rate) ? 0 : rate) + '</span></br>'
+      leftRateStr = leftRateStr + `<span class=${currentDrug + 'ToolTip'}` + '>' + (isNaN(rate) ? getText(rate) : rate) + '</span></br>'
     }
     return leftRateStr;
   }
@@ -638,13 +654,13 @@ function LineChart({ params }) {
       for (var i in selectedDrugs) {
         if (selectedDrugs[i].includes(currentDrug)) {
           let cnt = getCountforDrug(selectedDrugs[i], parmState, val);
-          leftCntStr = leftCntStr + `<span class=${selectedDrugs[i] + 'ToolTip'}` + '>' + (isNaN(cnt) ? 0 : cnt) + '</span></br>'
+          leftCntStr = leftCntStr + `<span class=${selectedDrugs[i] + 'ToolTip'}` + '>' + (isNaN(cnt) ? getText(cnt) : cnt) + '</span></br>'
         }
       }
     }
     else {
       let cnt = getCountforDrug(currentDrug, parmState, val);
-      leftCntStr = leftCntStr + `<span class=${currentDrug + 'ToolTip'}` + '>' + (isNaN(cnt) ? 0 : cnt) + '</span></br>'
+      leftCntStr = leftCntStr + `<span class=${currentDrug + 'ToolTip'}` + '>' + (isNaN(cnt) ? getText(cnt) : cnt) + '</span></br>'
     }
     return leftCntStr;
   }
@@ -807,6 +823,15 @@ function LineChart({ params }) {
     return val;
   }
 
+  function getSymbol(val) {
+    if (val == 'Data not available')
+      return '†';
+    else if (val == 'Data suppressed*')
+      return '*';
+    else
+      return '';
+  }
+
   const buildLineForDrug = (currentDrug) => {
 
     const sectionWidth = specs.xMax / specs.xValues.length;
@@ -837,9 +862,12 @@ function LineChart({ params }) {
                             <line x1={specs.xScale(d[specs.xKey]) ?? 0} y1={specs.yScale(d[currentDrug]) ?? 0} x2={specs.xScale(dNext[specs.xKey]) ?? 0} y2={specs.yScale(dNext[currentDrug]) ?? 0} stroke={UtilityFunctions.getSeriesColor(currentDrug, key)} strokeWidth={3} />
                           }
                           {(!isNaN(d[currentDrug]) && key == 'US') && <text x={i == 0 ? specs.xScale(d[specs.xKey]) :  specs.xScale(d[specs.xKey])} y={specs.yScale(d[currentDrug])-8} stroke={''} fill={''} fontSize={12} textAnchor={i == 0 ? 'right' : 'middle'}>{showLabels ? d[currentDrug] : ''}</text>}
+                          {(isNaN(d[currentDrug]) && key == 'US') && <text x={i == 0 ? specs.xScale(d[specs.xKey]) :  specs.xScale(d[specs.xKey])} y={specs.yScale(0)-8} stroke={''} fill={''} fontSize={12} textAnchor={'middle'} fontWeight={'bold'}>{getSymbol(d[currentDrug])}</text>}
+                          {(!isNaN(d[currentDrug]) && key == 'US') && <Circle cx={specs.xScale(d[specs.xKey])} cy={Number(d[currentDrug]) == 0 ? (specs.yScale(0)-14) : (specs.yScale(d[currentDrug]))} r={currentTimeframe === 'Monthly' ? 4: 5} fill={currentTimeframe === 'Monthly' && d[specs.xKey] == currentMonth ? 'orange' : UtilityFunctions.getSeriesColor(currentDrug, key)} />}
+
                           {(!isNaN(d[currentDrug]) && key != 'US') && <text x={i == 0 ? specs.xScale(d[specs.xKey]) :  specs.xScale(d[specs.xKey])} y={specs.yScale(d[currentDrug])-8} stroke={'lightblue'} fill={'lightblue'} fontSize={12} textAnchor={i == 0 ? 'right' : 'middle'}>{showLabels ? d[currentDrug] : ''}</text>}
-                          {(!isNaN(d[currentDrug]) && key == 'US') && <Circle cx={specs.xScale(d[specs.xKey])} cy={specs.yScale(d[currentDrug])} r={currentTimeframe === 'Monthly' ? 4: 5} fill={currentTimeframe === 'Monthly' && d[specs.xKey] == currentMonth ? 'orange' : UtilityFunctions.getSeriesColor(currentDrug, key)} />}
-                          {(!isNaN(d[currentDrug]) && key != 'US') && <Circle cx={specs.xScale(d[specs.xKey])} cy={specs.yScale(d[currentDrug])} r={currentTimeframe === 'Monthly' ? 4: 5} fill={currentTimeframe === 'Monthly' && d[specs.xKey] == currentMonth ? 'orange' : UtilityFunctions.getSeriesColor(currentDrug, key)} />}
+                          {(isNaN(d[currentDrug]) && key != 'US') && <text x={i == 0 ? specs.xScale(d[specs.xKey]) :  specs.xScale(d[specs.xKey])} y={specs.yScale(0)-8} stroke={'lightblue'} fill={'lightblue'} fontSize={12} textAnchor={'middle'} fontWeight={'bold'}>{getSymbol(d[currentDrug])}</text>}
+                          {(!isNaN(d[currentDrug]) && key != 'US') && <Circle cx={specs.xScale(d[specs.xKey])} cy={Number(d[currentDrug]) == 0 ? (specs.yScale(0)-14) : (specs.yScale(d[currentDrug]))} r={currentTimeframe === 'Monthly' ? 4: 5} fill={currentTimeframe === 'Monthly' && d[specs.xKey] == currentMonth ? 'orange' : UtilityFunctions.getSeriesColor(currentDrug, key)} />}
                         </Group>
                       )
                     })}

--- a/src/components/SexAgeCharts.js
+++ b/src/components/SexAgeCharts.js
@@ -61,7 +61,7 @@ function SexAgeCharts({ params }) {
     const x2Pos = isNaN(d[x2Key]) ? xMaxHalf + 15 : x2Scale(d[x2Key]);
 
     const x1Tip = `<div class="tooltipTableLC"><p><strong>Age</strong>: ${d[yKey]}</p><p><strong>Sex</strong>: Male</p><p><strong>${currentDataType === 'count' ? 'Overdoses' : 'Rate'}</strong>: ${isNaN(d[x1Key]) ? formatToolTip(d[x1Key]) : d[x1Key].toLocaleString()}</p></div>`;
-    const x2Tip = `<div class="tooltipTableLC"<p><strong>Age</strong>: ${d[yKey]}</p><p><strong>Sex</strong>: Female</p><p><strong>${currentDataType === 'count' ? 'Overdoses' : 'Rate'}</strong>: ${isNaN(d[x2Key]) ? formatToolTip(d[x2Key]) : d[x2Key].toLocaleString()}</p></div>`;
+    const x2Tip = `<div class="tooltipTableLC"><p><strong>Age</strong>: ${d[yKey]}</p><p><strong>Sex</strong>: Female</p><p><strong>${currentDataType === 'count' ? 'Overdoses' : 'Rate'}</strong>: ${isNaN(d[x2Key]) ? formatToolTip(d[x2Key]) : d[x2Key].toLocaleString()}</p></div>`;
 
     const alignEndFirst = x1Pos > (xMaxHalf - 50);
     const alignEndSecond = x2Pos - xMaxHalf > 55;

--- a/src/components/SexAgeCharts.js
+++ b/src/components/SexAgeCharts.js
@@ -46,13 +46,22 @@ function SexAgeCharts({ params }) {
     padding: .2,
   });
 
+  const formatToolTip = (val) => {
+      if (val.includes('Data suppressed'))
+          return 'Data suppressed';
+      else if (val.includes('Data not available'))
+        return 'Data not available/not reported';
+      else
+        return ''
+  }
+
   const getBar = (d) => {
 
     const x1Pos = isNaN(d[x1Key]) ? xMaxHalf - 15 : x1Scale(d[x1Key]);
     const x2Pos = isNaN(d[x2Key]) ? xMaxHalf + 15 : x2Scale(d[x2Key]);
 
-    const x1Tip = `<div class="tooltipTableLC"><p><strong>Age</strong>: ${d[yKey]}</p><p><strong>Sex</strong>: Male</p><p><strong>${currentDataType === 'count' ? 'Overdoses' : 'Rate'}</strong>: ${d[x1Key].toLocaleString()}</p></div>`;
-    const x2Tip = `<div class="tooltipTableLC"<p><strong>Age</strong>: ${d[yKey]}</p><p><strong>Sex</strong>: Female</p><p><strong>${currentDataType === 'count' ? 'Overdoses' : 'Rate'}</strong>: ${d[x2Key].toLocaleString()}</p></div>`;
+    const x1Tip = `<div class="tooltipTableLC"><p><strong>Age</strong>: ${d[yKey]}</p><p><strong>Sex</strong>: Male</p><p><strong>${currentDataType === 'count' ? 'Overdoses' : 'Rate'}</strong>: ${isNaN(d[x1Key]) ? formatToolTip(d[x1Key]) : d[x1Key].toLocaleString()}</p></div>`;
+    const x2Tip = `<div class="tooltipTableLC"<p><strong>Age</strong>: ${d[yKey]}</p><p><strong>Sex</strong>: Female</p><p><strong>${currentDataType === 'count' ? 'Overdoses' : 'Rate'}</strong>: ${isNaN(d[x2Key]) ? formatToolTip(d[x2Key]) : d[x2Key].toLocaleString()}</p></div>`;
 
     const alignEndFirst = x1Pos > (xMaxHalf - 50);
     const alignEndSecond = x2Pos - xMaxHalf > 55;
@@ -66,7 +75,7 @@ function SexAgeCharts({ params }) {
           y={yScale(d[yKey]) + (yScale.bandwidth() / 2) + 5} 
           textAnchor={alignEndFirst ? 'end' : 'start'} 
           fill="black" 
-          fontSize={isSmallViewport ? fontSize * .8 : fontSize}>{d[x1Key]?.toLocaleString()}</Text>
+          fontSize={isSmallViewport ? fontSize * .8 : fontSize}>{isNaN(d[x1Key]) ? '' : (d[x1Key])?.toLocaleString()}</Text>
 
         {!isNaN(d[x2Key]) && <path d={Utils.horizontalBarPath(true, xMaxHalf, yScale(d[yKey]), (x2Pos - xMaxHalf), yScale.bandwidth(), 3, yScale.bandwidth() * .1)} fill={isNaN(d[x2Key]) ? 'transparent' : drugOptions[currentDrug].color} stroke={drugOptions[currentDrug].color} data-tip={x2Tip} />}
         {isNaN(d[x2Key]) && <Text x={x2Pos} y={yScale(d[yKey]) + (yScale.bandwidth() / 2) + 15} textAnchor="middle" alignmentBaseline="end" fill={drugOptions[currentDrug].color} fontSize={isSmallViewport ? fontSize * 1.6 : fontSize * 2} data-tip={x2Tip}>{d[x2Key]?.includes('Data suppressed') ? '*' : '†'}</Text>}
@@ -75,7 +84,7 @@ function SexAgeCharts({ params }) {
           y={yScale(d[yKey]) + (yScale.bandwidth() / 2) + 5} 
           textAnchor={alignEndSecond ? 'end' : 'start'} 
           fill={!isNaN(d[x2Key]) && alignEndSecond ? 'white' : 'black'} 
-          fontSize={isSmallViewport ? fontSize * .8 : fontSize}>{d[x2Key]?.toLocaleString()}</Text>
+          fontSize={isSmallViewport ? fontSize * .8 : fontSize}>{isNaN(d[x2Key]) ? '' : (d[x2Key])?.toLocaleString()}</Text>
       </g>
     )
   }

--- a/src/components/StateChart.js
+++ b/src/components/StateChart.js
@@ -19,8 +19,8 @@ const getData = (data, currentDataSource, currentTimeframe, currentMonth, curren
         var key = Object.keys(data.year[currentDataSource])[i];
         if (data.year[currentDataSource][key]){
           let rec = data.year[currentDataSource][key]['all'].find(d => d.year == String(currentYear));
-          if (rec)
-            finalData[stateNames[key]] = {rate: isNaN(rec[currentDrug]) ? '-1' : rec[currentDrug], stateKey: key, forTooltip: rec[currentDrug]};
+          if (rec && UtilityFunctions.isStateInSupportedStates(data.supportedJurisdictions, currentDataSource, currentYear, currentMonth, currentTimeframe, key))
+            finalData[stateNames[key]] = {rate: rec[currentDrug], stateKey: key, forTooltip: rec[currentDrug]};
           }
         }
         return finalData;
@@ -34,7 +34,7 @@ const getData = (data, currentDataSource, currentTimeframe, currentMonth, curren
     if(data && data.year[currentDataSource]) {
         for (let i = 0; i <= Object.keys(data.year[currentDataSource]).length - 1; i++) {
           var state = Object.keys(data.year[currentDataSource])[i]
-          var val = -1
+          var val;
           for (var x=0;x<=Object.keys(data.year[currentDataSource][state][currentMonth]).length - 1; x++)
           {
             if (data.year[currentDataSource][state][[currentMonth]][x].year === Number(currentYear))
@@ -67,7 +67,8 @@ const getData = (data, currentDataSource, currentTimeframe, currentMonth, curren
                 }
             }
 
-            finalData[stateNames[state]] = {rate: val, stateKey: state, forTooltip: String(val)};
+            if (UtilityFunctions.isStateInSupportedStates(data.supportedJurisdictions, currentDataSource, currentYear, currentMonth, currentTimeframe, state))
+              finalData[stateNames[state]] = {rate: val, stateKey: state, forTooltip: String(val)};
           }
 
       }
@@ -161,6 +162,15 @@ function StateChart(params) {
         return ''
   }
 
+  const formatToolTip = (val) => {
+      if (val.includes('Data suppressed'))
+          return 'Data suppressed';
+      else if (val.includes('Data not available'))
+        return 'Data not available/not reported';
+      else
+        return ''
+  }
+
   return width > 0 && (
     <>
     {accessible ? (
@@ -188,7 +198,7 @@ function StateChart(params) {
                 const name = d;
                 const rate = dataRates[name].rate;
                 const stateKey = dataRates[name].stateKey;
-                const toolTip = dataRates[name].forTooltip;
+                const toolTip = isNaN(dataRates[name].forTooltip) ? formatToolTip(dataRates[name].forTooltip) : dataRates[name].forTooltip;
 
                 return (
                   <Group key={`bar-${name}`}>
@@ -212,15 +222,16 @@ function StateChart(params) {
                         }
                       }}
                       data-tip={`<div class="tooltipTableLC"><strong>${name}</strong><br/><br/>
-                      Rate: ${rate < 0 ? toolTip : Number(rate).toLocaleString()}</div>`}
+                      Rate: ${isNaN(rate) ? toolTip : Number(rate).toFixed(1)}</div>`}
                     ></path>
                     <text 
                       className="bar-label"
-                      x={rate < 0 ? 10 : xScale(rate)}
+                      x={isNaN(rate) ? 0 : xScale(rate)}
                       y={yScale(name)}
-                      dy="12"
-                      dx="5">
-                        {rate < 0 ? (toolTip?.includes('Data suppressed') ? '*' : '†') : rate}
+                      dy={isNaN(rate) ? 15 : 12}
+                      dx={isNaN(rate) ? 0 : 5}
+                      data-tip={`<strong>${name}</strong><br/><br/>Rate: ${toolTip}`}>
+                        {isNaN(rate) ? (toolTip?.includes('Data suppressed') ? '*' : '†') : rate}
                     </text>
                   </Group>
                 )}

--- a/src/utility.js
+++ b/src/utility.js
@@ -343,6 +343,14 @@ export const UtilityFunctions = {
       }
     }
     return num;
-  }
+  },
+
+  isStateInSupportedStates: (supportedJuris, ds, yr, mon, tframe, state) => {
+    let monMain = tframe != 'Monthly' ? '00' : String(mon).padStart(2, '0');
+    let key = ds + '_' + yr + monMain;
+
+    let strStates = supportedJuris[key]?.split(',');
+    return strStates.includes(state);
+  },
 
 }


### PR DESCRIPTION
1. When we hover over a data point that is data not available (e.g., DE 2022 HOSP data), it says “0” (for rate and count) and this is incorrect. Instead, it should say (if the JSON file has associated records), "Data not available/not reported" (see red box). Note: this error also happens with OK 2018-2020 ED data. It should be (if the JSON file has **NO** records), just empty.
2. We did notice something in the review of the data on the  DOSE-DIS accessibility view. This table had values of -1, when it should be 'Data not available/not reported'.
3. When a state is selected (not overall) in the top drop-down menu at the very top of the dashboard, the hover-over for this trend figure also incorrectly shows 0s instead of "Data not available" for instances of fentanyl and methamphetamine (for both the selected state AND overall; see images). Both of these drugs are only shown for part of the time period  so should say "Data not available" (not 0) when relevant (see screenshots). 
4. When data are suppressed due to small counts (example below), the hover-over also shows "0" instead of "Data suppressed." The screenshot ex. below does have a couple of 0 data points, but the rest are suppressed and should say "Data suppressed" in the hover-over. I believe this issue happens any time there is data suppression due to small counts (i.e., any state, any drug where it occurs).

For more details, please refer to 'DOSE Dashboards Think Tank' chat.

Thanks.