### PR TITLE
Sravan-DOSE-Discharge-09302025-1500

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -348,7 +348,7 @@ export default function App(params) {
 
       case 'usaMap':
         if (currentDataSource == 'ED')
-          txt = 'How often did people visit the ED for nonfatal ' + drugOptions[currentDrug].titleAll.toLowerCase() + ' overdoses by county in ' + (currentYearGroup == 'all' ? supportedYears[0] + '-' + supportedYears[supportedYears.length - 1] : currentYear);
+          txt = 'How often did people visit the ED for nonfatal ' + drugOptions[currentDrug].titleAll.toLowerCase() + ' overdoses by county in ' + (currentYearGroup == 'all' ? supportedYears[supportedYears.length - 5] + '-' + supportedYears[supportedYears.length - 1] : currentYear);
 
         break;
     }


### PR DESCRIPTION
Idea-D-501: Although the toggle does change the title now, the years in the title are incorrect. It should say "2020-2024" in the title, as noted in the Word doc. Currently the dash board says "2018-2024" (i.e., 5-y rate for 2020-2024 is the only one we show on the dashboard now).

Thanks.