### PR TITLE
Sravan dose discharge 11172025 0800

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1703,14 +1703,14 @@ export default function App(params) {
             </header>
             <div className="callouts">
               <div style={{ 'borderLeft': '5px solid' + drugColor }}>
-                <span className="callout" style={{ 'color': drugColor }}>{totalOverdoses}</span>
+                <span className={!isNaN(totalOverdoses) ? "callout" : 'calloutSmall'} style={{ 'color': drugColor }}>{totalOverdoses}</span>
                 <div>
                   <span className='data-bite-title' style={{ color: drugColor }}>{stateNames[currentState]}</span>
                   <p>{currentTimeframe} number of nonfatal {drugOptions[currentDrug]['titleSingular'].toLowerCase()} overdose {dataSourceOptions[currentDataSource]['titleLowerCase']} in <strong>{currentTimeframe !== 'Annual' && monthNames[currentMonth]} {currentYear}</strong></p>
                 </div>
               </div>
               <div style={{ 'borderLeft': '5px solid' + drugColor }}>
-                <span className="callout" style={{ 'color': drugColor }}>{rateOverdoses || 'N/A'}</span>
+                <span className={!isNaN(rateOverdoses) ? "callout" : 'calloutSmall'} style={{ 'color': drugColor }}>{rateOverdoses || 'N/A'}</span>
                 <div>
                   <span className='data-bite-title' style={{ color: drugColor }}>{stateNames[currentState]}</span>
                   <p>Rate<sup>1</sup> of {dataSourceOptions[currentDataSource]['titleLowerCase']} for nonfatal {drugOptions[currentDrug]['titleSingular'].toLowerCase()} overdose in <strong>{currentTimeframe !== 'Annual' && monthNames[currentMonth]} {currentYear}</strong></p>

--- a/src/components/ChangeIndicator.js
+++ b/src/components/ChangeIndicator.js
@@ -38,7 +38,7 @@ function ChangeIndicator(params) {
                         (percentValue == 0 ? [] : decreaseArrayPoints.map(p => [p.x, p.y]))}
                     fill={colorScale[defaultValueIfEmpty(label, defaultLabelIfEmpty)]}
                 ></Polygon>
-                <text x={percentValue == 0 ? width/2 + 5 : width/2} y="60" textAnchor="middle" fontSize={percentValue == 0 ? 35 :15}
+                <text x={percentValue == 0 ? width/2 + 5 : width/2} y={percentValue > 0 ? height/2 + 5: height/2} textAnchor="middle" fontSize={percentValue == 0 ? 16 : 9}
                     stroke={percentValue == 0 ? colorScale[defaultValueIfEmpty(label, defaultLabelIfEmpty)] :'#fff'}
                 >
                     {Math.abs(percentValue).toFixed(1)}%

--- a/src/components/LineChart.js
+++ b/src/components/LineChart.js
@@ -864,17 +864,20 @@ function LineChart({ params }) {
       return false;
   }
 
-  function narrowPoints(xval) { //take Y Axis scale into consideration for diff not direct values which can lead to issues and ask Business what to do with 0.0s //SKV TODO
+  function narrowPoints(xval) {
 
     const usVal = inp.filteredData['US'].find(d => d[specs.xKey] === xval) || {};
     const stVal = inp.filteredData[currentState].find(d => d[specs.xKey] === xval) || {};
-    var diff;
-    if (parseFloat(usVal[currentDrug]) > parseFloat(stVal[currentDrug]))
-      diff = usVal[currentDrug] - stVal[currentDrug];
-    else
-      diff = stVal[currentDrug] - usVal[currentDrug];
+    const usValF = parseFloat(specs.yScale(parseFloat(usVal[currentDrug])));
+    const stValF = parseFloat(specs.yScale(parseFloat(stVal[currentDrug])));
 
-    if (diff <= 5)
+    var diff;
+    if (usValF > stValF)
+      diff = usValF - stValF;
+    else
+      diff = stValF - usValF;
+
+    if (diff <= 15)
       return true;
     else
       return false;
@@ -914,10 +917,10 @@ function LineChart({ params }) {
                       return (
                         <Group key={`line-path-${key}-point-${i}`}>
                           {(!isNaN(d[currentDrug]) && !isNaN(dNext[currentDrug]) && key == 'US') && 
-                            <line x1={specs.xScale(d[specs.xKey]) ?? 0} y1={getYValue(d, currentDrug)} x2={specs.xScale(dNext[specs.xKey]) ?? 0} y2={getYValue(dNext, currentDrug)} stroke={UtilityFunctions.getSeriesColor(currentDrug, key)} strokeWidth={3} />
+                            <line x1={specs.xScale(d[specs.xKey]) ?? 0} y1={getYValue(d, currentDrug)} x2={specs.xScale(dNext[specs.xKey]) ?? 0} y2={getYValue(dNext, currentDrug)} stroke={UtilityFunctions.getSeriesColorLine(currentDrug, key, true)} strokeWidth={3} />
                           }
                           {(!isNaN(d[currentDrug]) && !isNaN(dNext[currentDrug]) && key != 'US') && 
-                            <line x1={specs.xScale(d[specs.xKey]) ?? 0} y1={getYValue(d, currentDrug)} x2={specs.xScale(dNext[specs.xKey]) ?? 0} y2={getYValue(dNext, currentDrug)} stroke={UtilityFunctions.getSeriesColor(currentDrug, key)} strokeWidth={3} />
+                            <line x1={specs.xScale(d[specs.xKey]) ?? 0} y1={getYValue(d, currentDrug)} x2={specs.xScale(dNext[specs.xKey]) ?? 0} y2={getYValue(dNext, currentDrug)} stroke={UtilityFunctions.getSeriesColorLine(currentDrug, key, false)} strokeWidth={3} />
                           }
                           {(!isNaN(d[currentDrug]) && key == 'US') && currentState == 'US' &&
                             <text 
@@ -942,7 +945,7 @@ function LineChart({ params }) {
                               x1={specs.xScale(d[specs.xKey])}
                               y1={specs.yScale(d[currentDrug])}
                               x2={specs.xScale(d[specs.xKey])}
-                              y2={higherValue(xVal) == 'US' ? specs.yScale(d[currentDrug])-16 : specs.yScale(d[currentDrug])+16}
+                              y2={higherValue(xVal) == 'US' ? specs.yScale(d[currentDrug])-16 : specs.yScale(d[currentDrug]) + 18}
                               stroke="#666"
                               strokeWidth={0.7}
                               strokeDasharray="2,2"
@@ -950,7 +953,7 @@ function LineChart({ params }) {
                           />
                           }
                           {(isNaN(d[currentDrug]) && key == 'US') && <text x={i == 0 ? specs.xScale(d[specs.xKey]) :  specs.xScale(d[specs.xKey])} y={specs.yScale(0)-8} stroke={''} fill={''} fontSize={16} textAnchor={'middle'}>{getSymbol(d[currentDrug])}</text>}
-                          {(!isNaN(d[currentDrug]) && key == 'US') && <Circle cx={specs.xScale(d[specs.xKey])} cy={Number(d[currentDrug]) == 0 ? (specs.yScale(0)-14) : (specs.yScale(d[currentDrug]))} r={currentTimeframe === 'Monthly' ? 4: 5} fill={currentTimeframe === 'Monthly' && d[specs.xKey] == currentMonth ? 'orange' : UtilityFunctions.getSeriesColor(currentDrug, key)} />}
+                          {(!isNaN(d[currentDrug]) && key == 'US') && <Circle cx={specs.xScale(d[specs.xKey])} cy={Number(d[currentDrug]) == 0 ? (specs.yScale(0)-14) : (specs.yScale(d[currentDrug]))} r={currentTimeframe === 'Monthly' ? 4: 5} fill={currentTimeframe === 'Monthly' && d[specs.xKey] == currentMonth ? 'orange' : UtilityFunctions.getSeriesColorLine(currentDrug, key, true)} />}
                           {(!isNaN(d[currentDrug]) && key != 'US') && currentState == 'US' &&
                             <text 
                               x={i == 0 ? specs.xScale(d[specs.xKey]) :  specs.xScale(d[specs.xKey])} 
@@ -964,7 +967,7 @@ function LineChart({ params }) {
                           {(!isNaN(d[currentDrug]) && key != 'US') && currentState != 'US' && showLabels && 
                             <text 
                               x={i == 0 ? specs.xScale(d[specs.xKey]) :  specs.xScale(d[specs.xKey])} 
-                              y={!narrowPoints(xVal) ? specs.yScale(d[currentDrug])-8 : (higherValue(xVal) == currentState ? specs.yScale(d[currentDrug])-16 : specs.yScale(d[currentDrug])+28)}
+                              y={!narrowPoints(xVal) ? (d[currentDrug] == '0.0' ? specs.yScale(d[currentDrug])-22 : specs.yScale(d[currentDrug])-8) : (higherValue(xVal) == currentState ? specs.yScale(d[currentDrug])-16 : specs.yScale(d[currentDrug])+28)}
                               stroke={'lightblue'} fill={'lightblue'} 
                               fontSize={12} 
                               textAnchor={i == 0 ? 'right' : 'middle'}>
@@ -976,7 +979,7 @@ function LineChart({ params }) {
                               x1={specs.xScale(d[specs.xKey])}
                               y1={specs.yScale(d[currentDrug])}
                               x2={specs.xScale(d[specs.xKey])}
-                              y2={higherValue(xVal) == currentState ? specs.yScale(d[currentDrug])-16 : specs.yScale(d[currentDrug])+16}
+                              y2={higherValue(xVal) == currentState ? specs.yScale(d[currentDrug])-16 : specs.yScale(d[currentDrug]) + 18}
                               stroke="#666"
                               strokeWidth={0.7}
                               strokeDasharray="2,2"
@@ -986,7 +989,7 @@ function LineChart({ params }) {
                           {(isNaN(d[currentDrug]) && key != 'US') && 
                           <text x={i == 0 ? specs.xScale(d[specs.xKey]) :  specs.xScale(d[specs.xKey])} y={specs.yScale(0)-8} fontSize={16} textAnchor={'middle'}>{getSymbol(d[currentDrug])}</text>}
                           {(!isNaN(d[currentDrug]) && key != 'US') && 
-                          <Circle cx={specs.xScale(d[specs.xKey])} cy={Number(d[currentDrug]) == 0 ? (specs.yScale(0)-14) : (specs.yScale(d[currentDrug]))} r={currentTimeframe === 'Monthly' ? 4: 5} fill={currentTimeframe === 'Monthly' && d[specs.xKey] == currentMonth ? 'orange' : UtilityFunctions.getSeriesColor(currentDrug, key)} />}
+                          <Circle cx={specs.xScale(d[specs.xKey])} cy={Number(d[currentDrug]) == 0 ? (specs.yScale(0)-14) : (specs.yScale(d[currentDrug]))} r={currentTimeframe === 'Monthly' ? 4: 5} fill={currentTimeframe === 'Monthly' && d[specs.xKey] == currentMonth ? 'orange' : UtilityFunctions.getSeriesColorLine(currentDrug, key, false)} />}
                         </Group>
                       )
                     })}
@@ -1020,7 +1023,7 @@ function LineChart({ params }) {
                             y={yPos}
                             alignmentBaseline="middle" 
                             fontSize={specs.fontSize} 
-                            fill={UtilityFunctions.getSeriesColor(currentDrug, key)}>
+                            fill={UtilityFunctions.getSeriesColorLine(currentDrug, key, false)}>
                               {key != 'US' ? inp.stateNames[key] : 'Overall'}
                           </text>
                           {lastValuesSame() && key != 'US' && <line
@@ -1029,7 +1032,7 @@ function LineChart({ params }) {
                                 y1={yPos - specs.seriesOverlapMargin}
                                 x2={specs.xMax + 25} 
                                 y2={yPos}
-                                stroke={UtilityFunctions.getSeriesColor(currentDrug, key)}
+                                stroke={UtilityFunctions.getSeriesColorLine(currentDrug, key, false)}
                                 strokeWidth={0.5}/>}
                           </Group>
                             )
@@ -1051,7 +1054,7 @@ function LineChart({ params }) {
                                 y={yPos}
                                 alignmentBaseline="middle" 
                                 fontSize={specs.fontSize} 
-                                fill={UtilityFunctions.getSeriesColor(currentDrug, key)}>
+                                fill={UtilityFunctions.getSeriesColorLine(currentDrug, key,true)}>
                                   {drugOptions[currentDrug].titleForDropDown}
                               </text>
                             </Group>

--- a/src/components/LineChart.js
+++ b/src/components/LineChart.js
@@ -981,7 +981,8 @@ function LineChart({ params }) {
                             <text 
                               x={i == 0 ? specs.xScale(d[specs.xKey]) :  specs.xScale(d[specs.xKey])} 
                               y={!narrowPoints(xVal) ? (d[currentDrug] == '0.0' ? specs.yScale(d[currentDrug])-22 : specs.yScale(d[currentDrug])-8) : (higherValue(xVal) == currentState ? specs.yScale(d[currentDrug])-16 : specs.yScale(d[currentDrug])+28)}
-                              stroke={'lightblue'} fill={'lightblue'} 
+                              stroke={UtilityFunctions.getSeriesColorLine(currentDrug, key, false)} fill={UtilityFunctions.getSeriesColorLine(currentDrug, key, false)} 
+                              strokeWidth={0.25}
                               fontSize={12} 
                               textAnchor={i == 0 ? 'right' : 'middle'}>
                               {showLabels ? d[currentDrug] : ''}

--- a/src/components/LineChart.js
+++ b/src/components/LineChart.js
@@ -854,14 +854,27 @@ function LineChart({ params }) {
     return 0;
   }
 
-  function lastValuesSame() {
+  function lastValuesNarrow() {
     var stVal = inp.filteredData[currentState][inp.filteredData[currentState].length - 1][currentDrug];
     var usVal = inp.filteredData['US'][inp.filteredData[currentState].length - 1][currentDrug];
+    const usValF = parseFloat(specs.yScale(parseFloat(usVal)));
+    const stValF = parseFloat(specs.yScale(parseFloat(stVal)));
 
-    if (stVal == usVal)
+    var diff;
+    if (usValF > stValF)
+      diff = usValF - stValF;
+    else
+      diff = stValF - usValF;
+
+    if (diff <= 15)
       return true;
     else
       return false;
+  }
+
+  function lastValue() {
+    var stVal = inp.filteredData[currentState][inp.filteredData[currentState].length - 1][currentDrug];
+    return specs.yScale(parseFloat(stVal));
   }
 
   function narrowPoints(xval) {
@@ -1026,10 +1039,10 @@ function LineChart({ params }) {
                             fill={UtilityFunctions.getSeriesColorLine(currentDrug, key, false)}>
                               {key != 'US' ? inp.stateNames[key] : 'Overall'}
                           </text>
-                          {lastValuesSame() && key != 'US' && <line
+                          {lastValuesNarrow() && key != 'US' && <line
                                 id={`line-leading-${currentDrug}`}
                                 x1={specs.xMax + 4}
-                                y1={yPos - specs.seriesOverlapMargin}
+                                y1={lastValue()}
                                 x2={specs.xMax + 25} 
                                 y2={yPos}
                                 stroke={UtilityFunctions.getSeriesColorLine(currentDrug, key, false)}

--- a/src/components/LineChart.js
+++ b/src/components/LineChart.js
@@ -243,6 +243,7 @@ function LineChart({ params }) {
     domain: [Math.min(...specs.xValues), Math.max(...specs.xValues)],
     range: [10, specs.xMax]
   });
+  
   specs['yScale'] = scaleLinear({
     domain: [0, yScaleDomainPeriod], 
     range: [specs.yMax, 0],
@@ -841,6 +842,54 @@ function LineChart({ params }) {
       return '';
   }
 
+  function getYValue(d, currentDrug) {
+    var val = specs.yScale(d[currentDrug]) ?? 0;
+    if (val != 0)
+    {
+      if (Number(d[currentDrug]) == 0)
+        return specs.yScale(0)-14;
+      else
+        return specs.yScale(d[currentDrug]);
+    }
+    return 0;
+  }
+
+  function lastValuesSame() {
+    var stVal = inp.filteredData[currentState][inp.filteredData[currentState].length - 1][currentDrug];
+    var usVal = inp.filteredData['US'][inp.filteredData[currentState].length - 1][currentDrug];
+
+    if (stVal == usVal)
+      return true;
+    else
+      return false;
+  }
+
+  function narrowPoints(xval) { //take Y Axis scale into consideration for diff not direct values which can lead to issues and ask Business what to do with 0.0s //SKV TODO
+
+    const usVal = inp.filteredData['US'].find(d => d[specs.xKey] === xval) || {};
+    const stVal = inp.filteredData[currentState].find(d => d[specs.xKey] === xval) || {};
+    var diff;
+    if (parseFloat(usVal[currentDrug]) > parseFloat(stVal[currentDrug]))
+      diff = usVal[currentDrug] - stVal[currentDrug];
+    else
+      diff = stVal[currentDrug] - usVal[currentDrug];
+
+    if (diff <= 5)
+      return true;
+    else
+      return false;
+  }
+
+  function higherValue(xval) {
+
+    const usVal = inp.filteredData['US'].find(d => d[specs.xKey] === xval) || {};
+    const stVal = inp.filteredData[currentState].find(d => d[specs.xKey] === xval) || {};
+    if (parseFloat(usVal[currentDrug]) > parseFloat(stVal[currentDrug]))
+      return 'US';
+    else
+      return currentState;
+  }
+  
   const buildLineForDrug = (currentDrug) => {
 
     const sectionWidth = specs.xMax / specs.xValues.length;
@@ -865,18 +914,79 @@ function LineChart({ params }) {
                       return (
                         <Group key={`line-path-${key}-point-${i}`}>
                           {(!isNaN(d[currentDrug]) && !isNaN(dNext[currentDrug]) && key == 'US') && 
-                            <line x1={specs.xScale(d[specs.xKey]) ?? 0} y1={specs.yScale(d[currentDrug]) ?? 0} x2={specs.xScale(dNext[specs.xKey]) ?? 0} y2={specs.yScale(dNext[currentDrug]) ?? 0} stroke={UtilityFunctions.getSeriesColor(currentDrug, key)} strokeWidth={3} />
+                            <line x1={specs.xScale(d[specs.xKey]) ?? 0} y1={getYValue(d, currentDrug)} x2={specs.xScale(dNext[specs.xKey]) ?? 0} y2={getYValue(dNext, currentDrug)} stroke={UtilityFunctions.getSeriesColor(currentDrug, key)} strokeWidth={3} />
                           }
                           {(!isNaN(d[currentDrug]) && !isNaN(dNext[currentDrug]) && key != 'US') && 
-                            <line x1={specs.xScale(d[specs.xKey]) ?? 0} y1={specs.yScale(d[currentDrug]) ?? 0} x2={specs.xScale(dNext[specs.xKey]) ?? 0} y2={specs.yScale(dNext[currentDrug]) ?? 0} stroke={UtilityFunctions.getSeriesColor(currentDrug, key)} strokeWidth={3} />
+                            <line x1={specs.xScale(d[specs.xKey]) ?? 0} y1={getYValue(d, currentDrug)} x2={specs.xScale(dNext[specs.xKey]) ?? 0} y2={getYValue(dNext, currentDrug)} stroke={UtilityFunctions.getSeriesColor(currentDrug, key)} strokeWidth={3} />
                           }
-                          {(!isNaN(d[currentDrug]) && key == 'US') && <text x={i == 0 ? specs.xScale(d[specs.xKey]) :  specs.xScale(d[specs.xKey])} y={specs.yScale(d[currentDrug])-8} stroke={''} fill={''} fontSize={12} textAnchor={i == 0 ? 'right' : 'middle'}>{showLabels ? d[currentDrug] : ''}</text>}
+                          {(!isNaN(d[currentDrug]) && key == 'US') && currentState == 'US' &&
+                            <text 
+                              x={i == 0 ? specs.xScale(d[specs.xKey]) :  specs.xScale(d[specs.xKey])} 
+                              y={specs.yScale(d[currentDrug])-8}
+                              stroke={''} fill={''} 
+                              fontSize={12} textAnchor={i == 0 ? 'right' : 'middle'}>
+                                {showLabels ? d[currentDrug] : ''}
+                            </text>
+                          }
+                          {(!isNaN(d[currentDrug]) && key == 'US') && currentState != 'US' && showLabels && 
+                            <text 
+                              x={i == 0 ? specs.xScale(d[specs.xKey]) :  specs.xScale(d[specs.xKey])} 
+                              y={!narrowPoints(xVal) ? specs.yScale(d[currentDrug])-8 : (higherValue(xVal) == 'US' ? specs.yScale(d[currentDrug])-16 : specs.yScale(d[currentDrug])+28)} 
+                              stroke={''} fill={''} 
+                              fontSize={12} textAnchor={i == 0 ? 'right' : 'middle'}>
+                                {showLabels ? d[currentDrug] : ''}
+                            </text>
+                          }
+                          {(!isNaN(d[currentDrug]) && key == 'US' && currentState != 'US' && narrowPoints(xVal)) && showLabels && 
+                            <line
+                              x1={specs.xScale(d[specs.xKey])}
+                              y1={specs.yScale(d[currentDrug])}
+                              x2={specs.xScale(d[specs.xKey])}
+                              y2={higherValue(xVal) == 'US' ? specs.yScale(d[currentDrug])-16 : specs.yScale(d[currentDrug])+16}
+                              stroke="#666"
+                              strokeWidth={0.7}
+                              strokeDasharray="2,2"
+                              opacity={0.6}
+                          />
+                          }
                           {(isNaN(d[currentDrug]) && key == 'US') && <text x={i == 0 ? specs.xScale(d[specs.xKey]) :  specs.xScale(d[specs.xKey])} y={specs.yScale(0)-8} stroke={''} fill={''} fontSize={16} textAnchor={'middle'}>{getSymbol(d[currentDrug])}</text>}
                           {(!isNaN(d[currentDrug]) && key == 'US') && <Circle cx={specs.xScale(d[specs.xKey])} cy={Number(d[currentDrug]) == 0 ? (specs.yScale(0)-14) : (specs.yScale(d[currentDrug]))} r={currentTimeframe === 'Monthly' ? 4: 5} fill={currentTimeframe === 'Monthly' && d[specs.xKey] == currentMonth ? 'orange' : UtilityFunctions.getSeriesColor(currentDrug, key)} />}
-
-                          {(!isNaN(d[currentDrug]) && key != 'US') && <text x={i == 0 ? specs.xScale(d[specs.xKey]) :  specs.xScale(d[specs.xKey])} y={specs.yScale(d[currentDrug])-8} stroke={'lightblue'} fill={'lightblue'} fontSize={12} textAnchor={i == 0 ? 'right' : 'middle'}>{showLabels ? d[currentDrug] : ''}</text>}
-                          {(isNaN(d[currentDrug]) && key != 'US') && <text x={i == 0 ? specs.xScale(d[specs.xKey]) :  specs.xScale(d[specs.xKey])} y={specs.yScale(0)-8} fontSize={16} textAnchor={'middle'}>{getSymbol(d[currentDrug])}</text>}
-                          {(!isNaN(d[currentDrug]) && key != 'US') && <Circle cx={specs.xScale(d[specs.xKey])} cy={Number(d[currentDrug]) == 0 ? (specs.yScale(0)-14) : (specs.yScale(d[currentDrug]))} r={currentTimeframe === 'Monthly' ? 4: 5} fill={currentTimeframe === 'Monthly' && d[specs.xKey] == currentMonth ? 'orange' : UtilityFunctions.getSeriesColor(currentDrug, key)} />}
+                          {(!isNaN(d[currentDrug]) && key != 'US') && currentState == 'US' &&
+                            <text 
+                              x={i == 0 ? specs.xScale(d[specs.xKey]) :  specs.xScale(d[specs.xKey])} 
+                              y={specs.yScale(d[currentDrug])-8}
+                              stroke={'lightblue'} fill={'lightblue'} 
+                              fontSize={12} 
+                              textAnchor={i == 0 ? 'right' : 'middle'}>
+                              {showLabels ? d[currentDrug] : ''}
+                            </text>
+                          }
+                          {(!isNaN(d[currentDrug]) && key != 'US') && currentState != 'US' && showLabels && 
+                            <text 
+                              x={i == 0 ? specs.xScale(d[specs.xKey]) :  specs.xScale(d[specs.xKey])} 
+                              y={!narrowPoints(xVal) ? specs.yScale(d[currentDrug])-8 : (higherValue(xVal) == currentState ? specs.yScale(d[currentDrug])-16 : specs.yScale(d[currentDrug])+28)}
+                              stroke={'lightblue'} fill={'lightblue'} 
+                              fontSize={12} 
+                              textAnchor={i == 0 ? 'right' : 'middle'}>
+                              {showLabels ? d[currentDrug] : ''}
+                            </text>
+                          }
+                          {(!isNaN(d[currentDrug]) && key != 'US' & narrowPoints(xVal)) && currentState != 'US' && showLabels && 
+                            <line
+                              x1={specs.xScale(d[specs.xKey])}
+                              y1={specs.yScale(d[currentDrug])}
+                              x2={specs.xScale(d[specs.xKey])}
+                              y2={higherValue(xVal) == currentState ? specs.yScale(d[currentDrug])-16 : specs.yScale(d[currentDrug])+16}
+                              stroke="#666"
+                              strokeWidth={0.7}
+                              strokeDasharray="2,2"
+                              opacity={0.6}
+                          />
+                          }
+                          {(isNaN(d[currentDrug]) && key != 'US') && 
+                          <text x={i == 0 ? specs.xScale(d[specs.xKey]) :  specs.xScale(d[specs.xKey])} y={specs.yScale(0)-8} fontSize={16} textAnchor={'middle'}>{getSymbol(d[currentDrug])}</text>}
+                          {(!isNaN(d[currentDrug]) && key != 'US') && 
+                          <Circle cx={specs.xScale(d[specs.xKey])} cy={Number(d[currentDrug]) == 0 ? (specs.yScale(0)-14) : (specs.yScale(d[currentDrug]))} r={currentTimeframe === 'Monthly' ? 4: 5} fill={currentTimeframe === 'Monthly' && d[specs.xKey] == currentMonth ? 'orange' : UtilityFunctions.getSeriesColor(currentDrug, key)} />}
                         </Group>
                       )
                     })}
@@ -904,7 +1014,8 @@ function LineChart({ params }) {
                         }
     
                         if (currentState != 'US') {
-                          return <text 
+                          return (<Group>
+                            <text 
                             x={specs.xMax + 25} 
                             y={yPos}
                             alignmentBaseline="middle" 
@@ -912,6 +1023,16 @@ function LineChart({ params }) {
                             fill={UtilityFunctions.getSeriesColor(currentDrug, key)}>
                               {key != 'US' ? inp.stateNames[key] : 'Overall'}
                           </text>
+                          {lastValuesSame() && key != 'US' && <line
+                                id={`line-leading-${currentDrug}`}
+                                x1={specs.xMax + 4}
+                                y1={yPos - specs.seriesOverlapMargin}
+                                x2={specs.xMax + 25} 
+                                y2={yPos}
+                                stroke={UtilityFunctions.getSeriesColor(currentDrug, key)}
+                                strokeWidth={0.5}/>}
+                          </Group>
+                            )
                         }
                         else{
                           return (
@@ -1069,6 +1190,7 @@ function LineChart({ params }) {
                 </AxisBottom>
                 {(isPeriod && inp['numOfTicks'] > 12) && generateYearLabels()}
               </Group>
+
             </svg>
           {(currentDrug == 'fentanyl' || selectedDrugs.includes('fentanyl')) &&
           <table style={{width: '100%'}}>

--- a/src/components/LineChart.js
+++ b/src/components/LineChart.js
@@ -1036,7 +1036,7 @@ function LineChart({ params }) {
                             y={yPos}
                             alignmentBaseline="middle" 
                             fontSize={specs.fontSize} 
-                            fill={UtilityFunctions.getSeriesColorLine(currentDrug, key, false)}>
+                            fill={key != 'US' ? UtilityFunctions.getSeriesColorLine(currentDrug, key, false) : UtilityFunctions.getSeriesColorLine(currentDrug, key, true)}>
                               {key != 'US' ? inp.stateNames[key] : 'Overall'}
                           </text>
                           {lastValuesNarrow() && key != 'US' && <line

--- a/src/components/quickStat.js
+++ b/src/components/quickStat.js
@@ -9,8 +9,8 @@ function QuickStat(params) {
                         <div className="stats-section first">
                           <div id="stats-section-icon" className="" >
                             <ChangeIndicator
-                              width={110}
-                              height={100}
+                              width={55}
+                              height={50}
                               colorScale={colorScale}
                               defaultValueIfEmpty={defaultValueIfEmpty}
                               percentValue={value}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -435,6 +435,21 @@ margin-top: .5em;
 }
 }
 
+span.calloutSmall {
+font-size: 1.5em;
+font-weight: 500;
+color: #712177;
+padding: 0 .5em 0 .1em;
+// font-family: "Merriweather", serif;
+align-self: flex-start;
+margin-top: .25em;
+
+&+div {
+align-self: flex-start;
+margin-top: .5em;
+}
+}
+
 p {
 font-size: .85em;
 }
@@ -1211,6 +1226,7 @@ margin-top: 10px;
 width: 70%;
 display: inline-block;
 padding: 0.25em;
+font-size: 14px;
 }
 
 .stats-section .stat-number
@@ -1345,7 +1361,7 @@ width: 100%;
 .toolTipChgPerc
 {
 display: flex;
-width: 320px;
+width: 200px;
 height: 120px;
 }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -395,7 +395,7 @@ opacity: 1;
 line-height: 1;
 font-size: 1em;
 border-radius: 4px;
-padding: 15px;
+padding: 6px;
 }
 
 .callouts {
@@ -1202,7 +1202,7 @@ padding-top: 0.5em;
 }
 
 .stats-section {
-border: 1px solid rgba(0,0,0,.125);
+border: 0px solid rgba(0,0,0,.125);
 border-left: 5px solid #b890bb;
 border-radius: .25rem;
 transition: .25s box-shadow;
@@ -1391,6 +1391,7 @@ padding-bottom: 25px!important;
 {
 background-color: white;
 padding: 5px;
+margin: 5px;
 text-align: left!important;
 }
 
@@ -1398,6 +1399,7 @@ text-align: left!important;
 {
 background-color: white;
 padding: 5px;
+margin: 5px;
 text-align: center!important;
 }
 
@@ -1405,6 +1407,7 @@ text-align: center!important;
 {
 background-color: white;
 padding: 5px;
+margin: 5px;
 text-align: center!important;
 }
 

--- a/src/utility.js
+++ b/src/utility.js
@@ -34,6 +34,74 @@ export const UtilityFunctions = {
       return seriesColor;
   },
 
+  getSeriesColorLine : (currentDrug, key, showOverall) => {
+
+    var seriesColor;
+  
+    if (!showOverall) {
+      
+      switch (currentDrug) {
+        case 'alldrug':
+          seriesColor = 'rgb(56, 71, 102)';
+          break;
+        case 'opioid':
+          seriesColor = 'rgb(0, 12, 119)';
+          break;
+        case 'heroin':
+          seriesColor = 'rgb(12, 111, 150)';
+          break;
+        case 'stimulant':
+          seriesColor = 'rgb(65, 27, 109)';
+          break;
+        case 'benzodiazepine':
+          seriesColor = 'rgb(184, 58, 94)';
+          break;
+        case 'fentanyl':
+          seriesColor = 'rgb(41, 72, 145)';
+          break;
+        case 'cocaine':
+          seriesColor = 'rgb(103, 26, 170)';
+          break;
+        case 'methamphetamine':
+          seriesColor = 'rgb(163, 120, 232)';
+          break;
+        }
+    
+        return seriesColor;
+    }
+    else
+    {
+      switch (currentDrug) {
+        case 'alldrug':
+          seriesColor = (key !== 'US') ? 'rgb(56, 71, 102)' : 'rgb(56, 71, 102, 0.65)';
+          break;
+        case 'opioid':
+          seriesColor = (key !== 'US') ? 'rgb(0, 12, 119)' : 'rgb(0, 12, 119, 0.65)';
+          break;
+        case 'heroin':
+          seriesColor = (key !== 'US') ? 'rgb(12, 111, 150)' : 'rgb(12, 111, 150, 0.65)';
+          break;
+        case 'stimulant':
+          seriesColor = (key !== 'US') ? 'rgb(65, 27, 109)' : 'rgb(65, 27, 109, 0.65)';
+          break;
+        case 'benzodiazepine':
+          seriesColor = (key !== 'US') ? 'rgb(184, 58, 94)' : 'rgb(184, 58, 94, 0.65)';
+          break;
+        case 'fentanyl':
+          seriesColor = (key !== 'US') ? 'rgb(41, 72, 145)' : 'rgb(41, 72, 145, 0.65)';
+          break;
+        case 'cocaine':
+          seriesColor = (key !== 'US') ? 'rgb(103, 26, 170)' : 'rgb(103, 26, 170, 0.65)';
+          break;
+        case 'methamphetamine':
+          seriesColor = (key !== 'US') ? 'rgb(163, 120, 232)' : 'rgb(163, 120, 232, 0.65)';
+          break;
+        }
+      
+          return seriesColor;
+        }
+  },
+
  calculateYScaleDomain: (filteredData, currentDrug, selectedDrugs, currentState)=> {
 
     var usNums = [];


### PR DESCRIPTION
IDEA-D 516: Please decreased the font size within the banner where is says "data is suppressed or data is not available" Please see screenshot attachment for guidance.
IDEA-D 517: There are breaks between the data point and the line in the trend plot on the dev site when annual methamphetamines data for Iowa in 2023 are selected. This applies to both ED and inpatient hospitalizations. The line doesn't appear to be connected to the data point (the data point is 0 this may also occur at other times data points are 0)
IDEA-D 518: In the event that both Overall Rate and State Rate are the same, it is hard to tell that the state rate even exists. We want to indicate that both rates are present, just overlapping each other.
IDEA-D 519: In the DIS line graph, we would like the state (or DC) line to be darker than the US/overall line. This would be changing to a similar color schema to the DOSE-SYS line graph, where the state line is always darker color than the US/overall line. 
Seung Hee Requirement: In Line Chart, when "state" and "overall" lines have closer data points, the labels are getting overlapped and user is not able to be read. Also reduce the size of the percentage hover tooltip that comes when "Chg %" toggle is on, to see data points clearly. 

Thanks.
