### PR TITLE
Sravan DOSE discharge 12022025 1100

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -192,9 +192,10 @@ export default function App(params) {
   const [showDatatable, setDatatable] = useState(false);
   const [showConsiderations, setConsiderations] = useState(false);
   const [showFootnotes, setFootnotes] = useState(false);
-  const [showStateTable, setStateTable] = useState(false);
+  const [showStateTable, setStateTable] = useState(true);
   const [showLabels, setLabelToggle] = useState(false);
   const [showPercent, setPercentToggle] = useState(false);
+  const [showCount, setCountToggle] = useState(false);
   const [isPeriod, setPeriodToggle] = useState(false);
   const [selectAllFlag, setSelectAllFlag] = useState(false);
   const [deselectAllFlag, setDeselectAllFlag] = useState(false);
@@ -202,9 +203,7 @@ export default function App(params) {
   const [selectedDrugs, setselectedDrugs] = useState(['alldrug']);
   const [timeframeChanged, setTimeframeChanged] = useState(false);
   const [activeTab, setActiveTab] = useState(0);
-  //const { accessible } = params;
-
-  const accessible = true;
+  const { accessible } = params;
 
   const [width, setWidth] = useState(accessible ? 0 : 100);
   
@@ -654,6 +653,25 @@ export default function App(params) {
                         </label>
                       </div>
                     }
+                    {accessible &&
+                      <div style={{ float: 'left' }}>
+                        <label class="toggleB" title={'Toggle to see count.'}>
+                          <input id="toggleBCount" class="toggleB-input" type="checkbox" checked={showCount}
+                            onChange={(e) => {
+                              if (e.target.checked) {
+                                setCountToggle(true)
+                              }
+                              else {
+                                setCountToggle(false)
+                              }
+                            }} />
+                          <span class="toggleB-label" data-off="Count Off"
+                            data-on="Count On">
+                          </span>
+                          <span class="toggleB-handle"></span>
+                        </label>
+                      </div>
+                    }
                   </td>
                 </tr>
               </table>
@@ -672,7 +690,6 @@ export default function App(params) {
               </td>
             }
           </tr>
-
           </table>
         }
         {isSmallViewport && 
@@ -1296,7 +1313,7 @@ export default function App(params) {
           <td>
             <div class="containerLC">
               <div class={currentState === 'US' ? "chartDivAll" : "chartDivAll"}>
-                <LineChart params={{ data, monthNames, stateNames, drugOptions, currentTimeframe, currentDataSource, currentDrug, currentState, currentYear, currentMonth, width, stateDropdownOptions, lookupPeriodStartYear, lookupPeriodStartMonth, lookupPeriodEndYear, lookupPeriodEndMonth, showLabels, showPercent, isPeriod, currentDrugOnly, supportedYears, selectedDrugs, accessible }} />
+                <LineChart params={{ data, monthNames, stateNames, drugOptions, currentTimeframe, currentDataSource, currentDrug, currentState, currentYear, currentMonth, width, stateDropdownOptions, lookupPeriodStartYear, lookupPeriodStartMonth, lookupPeriodEndYear, lookupPeriodEndMonth, showLabels, showPercent, showCount, isPeriod, currentDrugOnly, supportedYears, selectedDrugs, accessible }} />
               </div>
             </div>
           </td>
@@ -1308,7 +1325,7 @@ export default function App(params) {
 
       </table>
     </>,
-    [data, monthNames, stateNames, drugOptions, currentTimeframe, currentDataSource, currentDrug, currentState, currentYear, currentMonth, width, stateDropdownOptions, lookupPeriodStartYear, lookupPeriodStartMonth, lookupPeriodEndYear, lookupPeriodEndMonth, showLabels, showPercent, isPeriod, currentDrugOnly, supportedYears, selectedDrugs]);
+    [data, monthNames, stateNames, drugOptions, currentTimeframe, currentDataSource, currentDrug, currentState, currentYear, currentMonth, width, stateDropdownOptions, lookupPeriodStartYear, lookupPeriodStartMonth, lookupPeriodEndYear, lookupPeriodEndMonth, showLabels, showPercent, showCount, isPeriod, currentDrugOnly, supportedYears, selectedDrugs]);
 
   const sexAgeChartsMemo = useMemo(() =>
     <>
@@ -1741,42 +1758,45 @@ export default function App(params) {
               {accessible && getFootNotesForData('Line', true)}
             </section>
 
-            <section>
-              <div className="datatable-container-header">
-                <button className="h2 h2-toggle button-toggle" style={{ backgroundColor: drugOptions[selectedDrugsState[0]].color }} onClick={toggleStateTable}>
-                <text className="data-bite-header-toggle sub" style={{ backgroundColor: drugOptions[selectedDrugsState[0]].color }}>{getSubBannerText('statebarChart')}<sup>3,4</sup>?</text>
-                {showStateTable && <span>{String.fromCharCode(8722)}</span>}
-                {!showStateTable && <span>{String.fromCharCode(43)}</span>}
-                </button>
-                {showStateTable &&
-                  <div className="datatable-body">
-                    <table>
-                      <tr>
-                            <td style={{'width': '8%'}}></td>
-                            <td style={{'width': '84%'}}>
-                              <table style={{'border':'solid 2px gray', 'padding':'10px', 'borderRadius': '10px'}}>
-                                <tr>
-                                  <td style={{'width': '23%', 'verticalAlign': 'top'}}>
-                                    <div style={{'fontWeight': 'bold', 'textAlign': 'right', 'paddingTop': '3px', 'paddingLeft': '3px'}} className="select-input">Select Drug Syndrome:</div>
-                                    <div style={{'textAlign': 'left'}} className="select-input"><em>Click One</em></div>
-                                  </td>
-                                  <td class="drugsDivTop" style={{textAlign: 'left', verticalAlign: 'top', paddingLeft: '65px', paddingTop: '5px'}}>
-                                    {getDrugControlsState()}
-                                  </td>
-                                </tr>
-                                </table>
-                            </td>
-                            <td style={{'width': '8%'}}></td>
-                          </tr>
-                    </table>
-                    {stateBarChartMemo}
-                    {getFootNotesForData('State', false)}
-                  </div>
-                }
-            </div>
-          </section>
-            {/* <section>
-              <h2 className="data-bite-header sub" style={{ backgroundColor: drugOptions[selectedDrugsState[0]].color }}>{getSubBannerText('statebarChart')}<sup>3,4</sup>?</h2>
+            {accessible &&
+              <section>
+                <div className="datatable-container-header">
+                  <button className="h2 h2-toggle button-toggle" style={{ backgroundColor: drugOptions[selectedDrugsState[0]].color }} onClick={toggleStateTable}>
+                  <text className="data-bite-header-toggle sub" style={{ backgroundColor: drugOptions[selectedDrugsState[0]].color }}>{getSubBannerText('statebarChart')}<sup>3,4</sup>?</text>
+                  {showStateTable && <span>{String.fromCharCode(8722)}</span>}
+                  {!showStateTable && <span>{String.fromCharCode(43)}</span>}
+                  </button>
+                  {showStateTable &&
+                    <div className="datatable-body">
+                      <table>
+                        <tr>
+                              <td style={{'width': '8%'}}></td>
+                              <td style={{'width': '84%'}}>
+                                <table style={{'border':'solid 2px gray', 'padding':'10px', 'borderRadius': '10px'}}>
+                                  <tr>
+                                    <td style={{'width': '23%', 'verticalAlign': 'top'}}>
+                                      <div style={{'fontWeight': 'bold', 'textAlign': 'right', 'paddingTop': '3px', 'paddingLeft': '3px'}} className="select-input">Select Drug Syndrome:</div>
+                                      <div style={{'textAlign': 'left'}} className="select-input"><em>Click One</em></div>
+                                    </td>
+                                    <td class="drugsDivTop" style={{textAlign: 'left', verticalAlign: 'top', paddingLeft: '65px', paddingTop: '5px'}}>
+                                      {getDrugControlsState()}
+                                    </td>
+                                  </tr>
+                                  </table>
+                              </td>
+                              <td style={{'width': '8%'}}></td>
+                            </tr>
+                      </table>
+                      {stateBarChartMemo}
+                      {getFootNotesForData('State', false)}
+                    </div>
+                  }
+              </div>
+            </section>
+            }
+            {!accessible &&
+              <section>
+                <h2 className="data-bite-header sub" style={{ backgroundColor: drugOptions[selectedDrugsState[0]].color }}>{getSubBannerText('statebarChart')}<sup>3,4</sup>?</h2>
               <table>
                 <tr>
                       <td style={{'width': '8%'}}></td>
@@ -1798,7 +1818,8 @@ export default function App(params) {
               </table>
               {stateBarChartMemo}
               {getFootNotesForData('State', false)}
-            </section> */}
+              </section>
+            }
 
             <section>
               <h2 className="data-bite-header sub" style={{ backgroundColor: drugOptions[selectedDrugsSexAge[0]].color }}>{getSubBannerText('sexChart')}<sup>3,4</sup>?</h2>

--- a/src/App.js
+++ b/src/App.js
@@ -1774,11 +1774,11 @@ export default function App(params) {
                               <td style={{'width': '84%'}}>
                                 <table style={{'border':'solid 2px gray', 'padding':'10px', 'borderRadius': '10px'}}>
                                   <tr>
-                                    <td style={{'width': '23%', 'verticalAlign': 'top'}}>
+                                    <td style={{'width': '25%', 'verticalAlign': 'top'}}>
                                       <div style={{'fontWeight': 'bold', 'textAlign': 'right', 'paddingTop': '3px', 'paddingLeft': '3px'}} className="select-input">Select Drug Syndrome:</div>
                                       <div style={{'textAlign': 'left'}} className="select-input"><em>Click One</em></div>
                                     </td>
-                                    <td class="drugsDivTop" style={{textAlign: 'left', verticalAlign: 'top', paddingLeft: '65px', paddingTop: '5px'}}>
+                                    <td class="drugsDivTop" style={{'width': '75%', textAlign: 'left', verticalAlign: 'top', paddingLeft: '65px', paddingTop: '5px'}}>
                                       {getDrugControlsState()}
                                     </td>
                                   </tr>

--- a/src/App.js
+++ b/src/App.js
@@ -618,7 +618,7 @@ export default function App(params) {
                     {(currentTimeframe === 'Annual') &&
                       <div style={{ float: 'right' }}>
                         <label class="toggleA" title={'Toggle to hover over a data point on the line chart to view percent change for the selected year compared to the previous year.'}>
-                          <input id="togglePercent" class="toggleA-input" type="checkbox" checked={showPercent}
+                          <input id="togglePercent" class="toggleA-input" type="checkbox" checked={showPercent} disabled={showCount}
                             onChange={(e) => {
                               if (e.target.checked) {
                                 setPercentToggle(true)
@@ -656,7 +656,7 @@ export default function App(params) {
                     {accessible &&
                       <div style={{ float: 'left' }}>
                         <label class="toggleB" title={'Toggle to see count.'}>
-                          <input id="toggleBCount" class="toggleB-input" type="checkbox" checked={showCount}
+                          <input id="toggleBCount" class="toggleB-input" type="checkbox" checked={showCount} disabled={showPercent}
                             onChange={(e) => {
                               if (e.target.checked) {
                                 setCountToggle(true)

--- a/src/App.js
+++ b/src/App.js
@@ -202,6 +202,7 @@ export default function App(params) {
   const [timeframeChanged, setTimeframeChanged] = useState(false);
   const [activeTab, setActiveTab] = useState(0);
   const { accessible } = params;
+
   const [width, setWidth] = useState(accessible ? 0 : 100);
   
   const dataPath = window.location.origin.includes('localhost') ? '/data/' : '/overdose-prevention/data-dashboards/dose-discharge-dashboard/data/';
@@ -1703,7 +1704,8 @@ export default function App(params) {
             </header>
             <div className="callouts">
               <div style={{ 'borderLeft': '5px solid' + drugColor }}>
-                <span className={!isNaN(totalOverdoses) ? "callout" : 'calloutSmall'} style={{ 'color': drugColor }}>{totalOverdoses}</span>
+                {totalOverdoses == 'Data not available' && currentYear == '2024' && <span className={!isNaN(totalOverdoses) ? "callout" : 'calloutSmall'} style={{ 'color': drugColor }}>{totalOverdoses}<sup>§</sup></span>}
+                {totalOverdoses != 'Data not available' && currentYear != '2024' && <span className={!isNaN(totalOverdoses) ? "callout" : 'calloutSmall'} style={{ 'color': drugColor }}>{!isNaN(totalOverdoses) ? totalOverdoses.toLocaleString('en-US') : totalOverdoses}</span>}
                 <div>
                   <span className='data-bite-title' style={{ color: drugColor }}>{stateNames[currentState]}</span>
                   <p>{currentTimeframe} number of nonfatal {drugOptions[currentDrug]['titleSingular'].toLowerCase()} overdose {dataSourceOptions[currentDataSource]['titleLowerCase']} in <strong>{currentTimeframe !== 'Annual' && monthNames[currentMonth]} {currentYear}</strong></p>
@@ -1788,7 +1790,7 @@ export default function App(params) {
 
             <section>
               {usaMapMemo}
-              {accessible && getFootNotesForData('Map', false)}
+              {(accessible && (currentDataSource == 'ED' && currentDrug == 'alldrug')) && getFootNotesForData('Map', false)}
             </section>
           </>
         )}

--- a/src/App.js
+++ b/src/App.js
@@ -192,6 +192,7 @@ export default function App(params) {
   const [showDatatable, setDatatable] = useState(false);
   const [showConsiderations, setConsiderations] = useState(false);
   const [showFootnotes, setFootnotes] = useState(false);
+  const [showStateTable, setStateTable] = useState(false);
   const [showLabels, setLabelToggle] = useState(false);
   const [showPercent, setPercentToggle] = useState(false);
   const [isPeriod, setPeriodToggle] = useState(false);
@@ -201,7 +202,9 @@ export default function App(params) {
   const [selectedDrugs, setselectedDrugs] = useState(['alldrug']);
   const [timeframeChanged, setTimeframeChanged] = useState(false);
   const [activeTab, setActiveTab] = useState(0);
-  const { accessible } = params;
+  //const { accessible } = params;
+
+  const accessible = true;
 
   const [width, setWidth] = useState(accessible ? 0 : 100);
   
@@ -210,6 +213,7 @@ export default function App(params) {
   const toggleDatatable = () => setDatatable(!showDatatable);
   const toggleConsiderations = () => setConsiderations(!showConsiderations);
   const toggleFootnotes = () => setFootnotes(!showFootnotes);
+  const toggleStateTable = () => setStateTable(!showStateTable);
 
   const isSmallViewport = width < viewportCutoffSmall;
 
@@ -1738,6 +1742,40 @@ export default function App(params) {
             </section>
 
             <section>
+              <div className="datatable-container-header">
+                <button className="h2 h2-toggle button-toggle" style={{ backgroundColor: drugOptions[selectedDrugsState[0]].color }} onClick={toggleStateTable}>
+                <text className="data-bite-header-toggle sub" style={{ backgroundColor: drugOptions[selectedDrugsState[0]].color }}>{getSubBannerText('statebarChart')}<sup>3,4</sup>?</text>
+                {showStateTable && <span>{String.fromCharCode(8722)}</span>}
+                {!showStateTable && <span>{String.fromCharCode(43)}</span>}
+                </button>
+                {showStateTable &&
+                  <div className="datatable-body">
+                    <table>
+                      <tr>
+                            <td style={{'width': '8%'}}></td>
+                            <td style={{'width': '84%'}}>
+                              <table style={{'border':'solid 2px gray', 'padding':'10px', 'borderRadius': '10px'}}>
+                                <tr>
+                                  <td style={{'width': '23%', 'verticalAlign': 'top'}}>
+                                    <div style={{'fontWeight': 'bold', 'textAlign': 'right', 'paddingTop': '3px', 'paddingLeft': '3px'}} className="select-input">Select Drug Syndrome:</div>
+                                    <div style={{'textAlign': 'left'}} className="select-input"><em>Click One</em></div>
+                                  </td>
+                                  <td class="drugsDivTop" style={{textAlign: 'left', verticalAlign: 'top', paddingLeft: '65px', paddingTop: '5px'}}>
+                                    {getDrugControlsState()}
+                                  </td>
+                                </tr>
+                                </table>
+                            </td>
+                            <td style={{'width': '8%'}}></td>
+                          </tr>
+                    </table>
+                    {stateBarChartMemo}
+                    {getFootNotesForData('State', false)}
+                  </div>
+                }
+            </div>
+          </section>
+            {/* <section>
               <h2 className="data-bite-header sub" style={{ backgroundColor: drugOptions[selectedDrugsState[0]].color }}>{getSubBannerText('statebarChart')}<sup>3,4</sup>?</h2>
               <table>
                 <tr>
@@ -1760,7 +1798,7 @@ export default function App(params) {
               </table>
               {stateBarChartMemo}
               {getFootNotesForData('State', false)}
-            </section>
+            </section> */}
 
             <section>
               <h2 className="data-bite-header sub" style={{ backgroundColor: drugOptions[selectedDrugsSexAge[0]].color }}>{getSubBannerText('sexChart')}<sup>3,4</sup>?</h2>

--- a/src/accessibility.js
+++ b/src/accessibility.js
@@ -92,7 +92,58 @@ export const AccessibilityFunctions = {
         return '';
     },
 
-    generateLineChartData : (data, currentDrug, selDrugs, state, stateNames, currentTimeframe, showPercent, changePrecValues) => {
+    getCountMonthly : (drug, yr, st, data) => {
+      var cnt;
+      for (var i=0;i<Object.keys(data).length;i++) {
+        if (data[i].year == yr.substring(0,4) && data[i].month == String(Number(yr.substring(4))) && data[i].drug == drug) {
+          cnt = data[i].count;
+          break;
+        }
+      }
+
+      return cnt;
+    },
+
+    getCountYearly : (drug, yr, st, data) => {
+
+      var cnt;
+      for (var i=0;i<Object.keys(data).length;i++) {
+        if (data[i].year == yr && data[i].drug == drug) {
+          cnt = data[i].count;
+          break;
+        }
+      }
+
+      return cnt;
+    },
+
+    getCountMonthlyNonUS : (drug, yr, st, data, currentDataSource) => {
+      var cnt;
+      for (var i=0;i<Object.keys(data[currentDataSource][drug][String(Number(yr.substring(4)))]).length;i++) {
+            if (data[currentDataSource][drug][String(Number(yr.substring(4)))][i]['state'] == st)
+            {
+              cnt = data[currentDataSource][drug][String(Number(yr.substring(4)))][i][yr.substring(0,4)];
+              break;
+            }
+          }
+
+      return cnt;
+    },
+
+    getCountYearlyNonUS : (drug, yr, st, data, currentDataSource) => {
+      debugger;
+      var cnt;
+        for (var i=0;i<Object.keys(data[currentDataSource][drug]['all']).length;i++) {
+          if (data[currentDataSource][drug]['all'][i]['state'] == st) {
+            cnt = data[currentDataSource][drug]['all'][i][yr];
+            break;
+          }
+        }
+
+        return cnt;
+    },
+
+    generateLineChartData : (stateData, data, currentDataSource, countsDataYearly, countsDataMonthly, currentDrug, selDrugs, state, stateNames, currentTimeframe, showPercent, showCount, changePrecValues) => {
 
       let myData = {};
     
@@ -105,48 +156,79 @@ export const AccessibilityFunctions = {
 
             if (showPercent)
               obj['alldrug_pct'] = AccessibilityFunctions.getPercChange('alldrug', data['US'][i].year, state, changePrecValues);
+
+            if (showCount)
+              obj['alldrug_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('alldrug', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('alldrug', data['US'][i].year, state, countsDataYearly);
           }
 
           if (selDrugs.includes('benzodiazepine')) {
             obj['benzodiazepine'] = data['US'][i].benzodiazepine;
+
             if (showPercent)
               obj['benzodiazepine_pct'] = AccessibilityFunctions.getPercChange('benzodiazepine', data['US'][i].year, state, changePrecValues);
+
+            if (showCount)
+              obj['benzodiazepine_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('benzodiazepine', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('benzodiazepine', data['US'][i].year, state, countsDataYearly);
           }
 
           if (selDrugs.includes('cocaine')) {
             obj['cocaine'] = data['US'][i].cocaine;
+
             if (showPercent)
               obj['cocaine_pct'] = AccessibilityFunctions.getPercChange('cocaine', data['US'][i].year, state, changePrecValues);
+
+            if (showCount)
+              obj['cocaine_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('cocaine', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('cocaine', data['US'][i].year, state, countsDataYearly);
           }
 
           if (selDrugs.includes('fentanyl')) {
             obj['fentanyl'] = data['US'][i].fentanyl;
+
             if (showPercent)
               obj['fentanyl_pct'] = AccessibilityFunctions.getPercChange('fentanyl', data['US'][i].year, state, changePrecValues);
+
+            if (showCount)
+              obj['fentanyl_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('fentanyl', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('fentanyl', data['US'][i].year, state, countsDataYearly);
           }
 
           if (selDrugs.includes('heroin')) {
             obj['heroin'] = data['US'][i].heroin;
+
             if (showPercent)
               obj['heroin_pct'] = AccessibilityFunctions.getPercChange('heroin', data['US'][i].year, state, changePrecValues);
+
+            if (showCount)
+              obj['heroin_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('heroin', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('heroin', data['US'][i].year, state, countsDataYearly);
           }
 
           if (selDrugs.includes('methamphetamine')) {
             obj['methamphetamine'] = data['US'][i].methamphetamine;
+
             if (showPercent)
               obj['methamphetamine_pct'] = AccessibilityFunctions.getPercChange('methamphetamine', data['US'][i].year, state, changePrecValues);
+
+            if (showCount)
+              obj['methamphetamine_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('methamphetamine', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('methamphetamine', data['US'][i].year, state, countsDataYearly);
           }
 
           if (selDrugs.includes('opioid')) {
             obj['opioid'] = data['US'][i].opioid;
+
             if (showPercent)
               obj['opioid_pct'] = AccessibilityFunctions.getPercChange('opioid', data['US'][i].year, state, changePrecValues);
+
+            if (showCount)
+              obj['opioid_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('opioid', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('opioid', data['US'][i].year, state, countsDataYearly);
           }
 
           if (selDrugs.includes('stimulant')) {
             obj['stimulant'] = data['US'][i].stimulant;
+
             if (showPercent)
               obj['stimulant_pct'] = AccessibilityFunctions.getPercChange('stimulant', data['US'][i].year, state, changePrecValues);
+
+            if (showCount)
+              obj['stimulant_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('stimulant', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('stimulant', data['US'][i].year, state, countsDataYearly);
           }
 
           let monyr = currentTimeframe == 'Monthly' ? (UtilityFunctions.getMonthName(String(Number(data['US'][i].year.substring(4)))) + ' ' + data['US'][i].year.substring(0,4)) : data['US'][i].year;
@@ -160,22 +242,31 @@ export const AccessibilityFunctions = {
           let obj = {};
           if (currentDrug == 'alldrug') {
             obj['Overall'] = data['US'][i].alldrug;
+
             if (showPercent)
               obj['Overall_pct'] = data['US'][i].alldrug;
+
+            if (showCount)
+              obj['Overall_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthlyNonUS('alldrug', data['US'][i].year, state, stateData, currentDataSource) : AccessibilityFunctions.getCountYearlyNonUS('alldrug', data['US'][i].year, state, stateData, currentDataSource);
 
             obj['state'] = '';
             for (var j=0;j<Object.keys(data[state]).length;j++)
             {
               if (data['US'][i].year == data[state][j].year) {
                 obj['state'] = data[state][j].alldrug;
+
                 if (showPercent)
                   obj['state_pct'] = data[state][j].alldrug;
+
+                if (showCount)
+                  obj['state_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthlyNonUS('alldrug', data['US'][i].year, state, stateData) : AccessibilityFunctions.getCountYearlyNonUS('alldrug', data['US'][i].year, state, stateData);
               }
             }
           }
 
           if (currentDrug == 'benzodiazepine') {
             obj['Overall'] = data['US'][i].benzodiazepine;
+
             if (showPercent)
               obj['Overall_pct'] = data['US'][i].benzodiazepine;
 
@@ -294,5 +385,4 @@ export const AccessibilityFunctions = {
       return myData;
   
     },  
-  
 }

--- a/src/accessibility.js
+++ b/src/accessibility.js
@@ -105,7 +105,6 @@ export const AccessibilityFunctions = {
     },
 
     getCountYearly : (drug, yr, st, data) => {
-
       var cnt;
       for (var i=0;i<Object.keys(data).length;i++) {
         if (data[i].year == yr && data[i].drug == drug) {
@@ -131,7 +130,6 @@ export const AccessibilityFunctions = {
     },
 
     getCountYearlyNonUS : (drug, yr, st, data, currentDataSource) => {
-      debugger;
       var cnt;
         for (var i=0;i<Object.keys(data[currentDataSource][drug]['all']).length;i++) {
           if (data[currentDataSource][drug]['all'][i]['state'] == st) {
@@ -146,19 +144,17 @@ export const AccessibilityFunctions = {
     generateLineChartData : (stateData, data, currentDataSource, countsDataYearly, countsDataMonthly, currentDrug, selDrugs, state, stateNames, currentTimeframe, showPercent, showCount, changePrecValues) => {
 
       let myData = {};
-    
       if (state == 'US') {
         for (var i=0;i<Object.keys(data['US']).length;i++)
         {
           let obj = {};
+
           if (selDrugs.includes('alldrug')) {
             obj['alldrug'] = data['US'][i].alldrug;
 
             if (showPercent)
               obj['alldrug_pct'] = AccessibilityFunctions.getPercChange('alldrug', data['US'][i].year, state, changePrecValues);
 
-            if (showCount)
-              obj['alldrug_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('alldrug', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('alldrug', data['US'][i].year, state, countsDataYearly);
           }
 
           if (selDrugs.includes('benzodiazepine')) {
@@ -167,8 +163,6 @@ export const AccessibilityFunctions = {
             if (showPercent)
               obj['benzodiazepine_pct'] = AccessibilityFunctions.getPercChange('benzodiazepine', data['US'][i].year, state, changePrecValues);
 
-            if (showCount)
-              obj['benzodiazepine_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('benzodiazepine', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('benzodiazepine', data['US'][i].year, state, countsDataYearly);
           }
 
           if (selDrugs.includes('cocaine')) {
@@ -177,8 +171,6 @@ export const AccessibilityFunctions = {
             if (showPercent)
               obj['cocaine_pct'] = AccessibilityFunctions.getPercChange('cocaine', data['US'][i].year, state, changePrecValues);
 
-            if (showCount)
-              obj['cocaine_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('cocaine', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('cocaine', data['US'][i].year, state, countsDataYearly);
           }
 
           if (selDrugs.includes('fentanyl')) {
@@ -186,9 +178,6 @@ export const AccessibilityFunctions = {
 
             if (showPercent)
               obj['fentanyl_pct'] = AccessibilityFunctions.getPercChange('fentanyl', data['US'][i].year, state, changePrecValues);
-
-            if (showCount)
-              obj['fentanyl_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('fentanyl', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('fentanyl', data['US'][i].year, state, countsDataYearly);
           }
 
           if (selDrugs.includes('heroin')) {
@@ -197,8 +186,6 @@ export const AccessibilityFunctions = {
             if (showPercent)
               obj['heroin_pct'] = AccessibilityFunctions.getPercChange('heroin', data['US'][i].year, state, changePrecValues);
 
-            if (showCount)
-              obj['heroin_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('heroin', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('heroin', data['US'][i].year, state, countsDataYearly);
           }
 
           if (selDrugs.includes('methamphetamine')) {
@@ -207,8 +194,6 @@ export const AccessibilityFunctions = {
             if (showPercent)
               obj['methamphetamine_pct'] = AccessibilityFunctions.getPercChange('methamphetamine', data['US'][i].year, state, changePrecValues);
 
-            if (showCount)
-              obj['methamphetamine_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('methamphetamine', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('methamphetamine', data['US'][i].year, state, countsDataYearly);
           }
 
           if (selDrugs.includes('opioid')) {
@@ -217,8 +202,6 @@ export const AccessibilityFunctions = {
             if (showPercent)
               obj['opioid_pct'] = AccessibilityFunctions.getPercChange('opioid', data['US'][i].year, state, changePrecValues);
 
-            if (showCount)
-              obj['opioid_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('opioid', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('opioid', data['US'][i].year, state, countsDataYearly);
           }
 
           if (selDrugs.includes('stimulant')) {
@@ -227,12 +210,35 @@ export const AccessibilityFunctions = {
             if (showPercent)
               obj['stimulant_pct'] = AccessibilityFunctions.getPercChange('stimulant', data['US'][i].year, state, changePrecValues);
 
-            if (showCount)
-              obj['stimulant_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('stimulant', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('stimulant', data['US'][i].year, state, countsDataYearly);
           }
 
-          let monyr = currentTimeframe == 'Monthly' ? (UtilityFunctions.getMonthName(String(Number(data['US'][i].year.substring(4)))) + ' ' + data['US'][i].year.substring(0,4)) : data['US'][i].year;
-          myData[monyr] = obj;
+          if (showCount && selDrugs.includes('alldrug'))
+              obj['alldrug_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('alldrug', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('alldrug', data['US'][i].year, state, countsDataYearly);
+          
+            if (showCount && selDrugs.includes('benzodiazepine'))
+              obj['benzodiazepine_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('benzodiazepine', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('benzodiazepine', data['US'][i].year, state, countsDataYearly);
+          
+            if (showCount && selDrugs.includes('cocaine'))
+              obj['cocaine_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('cocaine', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('cocaine', data['US'][i].year, state, countsDataYearly);
+          
+            if (showCount && selDrugs.includes('fentanyl'))
+              obj['fentanyl_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('fentanyl', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('fentanyl', data['US'][i].year, state, countsDataYearly);
+          
+            if (showCount && selDrugs.includes('heroin'))
+              obj['heroin_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('heroin', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('heroin', data['US'][i].year, state, countsDataYearly);
+          
+            if (showCount && selDrugs.includes('methamphetamine'))
+              obj['methamphetamine_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('methamphetamine', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('methamphetamine', data['US'][i].year, state, countsDataYearly);
+          
+            if (showCount && selDrugs.includes('opioid'))
+              obj['opioid_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('opioid', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('opioid', data['US'][i].year, state, countsDataYearly);
+          
+            if (showCount && selDrugs.includes('stimulant'))
+              obj['stimulant_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('stimulant', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('stimulant', data['US'][i].year, state, countsDataYearly);
+
+            let monyr = currentTimeframe == 'Monthly' ? (UtilityFunctions.getMonthName(String(Number(data['US'][i].year.substring(4)))) + ' ' + data['US'][i].year.substring(0,4)) : data['US'][i].year;
+
+            myData[monyr] = obj;
         }
       }
       else
@@ -240,148 +246,103 @@ export const AccessibilityFunctions = {
         for (var i=0;i<Object.keys(data['US']).length;i++)
         {
           let obj = {};
+
           if (currentDrug == 'alldrug') {
             obj['Overall'] = data['US'][i].alldrug;
 
-            if (showPercent)
-              obj['Overall_pct'] = data['US'][i].alldrug;
-
-            if (showCount)
-              obj['Overall_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthlyNonUS('alldrug', data['US'][i].year, state, stateData, currentDataSource) : AccessibilityFunctions.getCountYearlyNonUS('alldrug', data['US'][i].year, state, stateData, currentDataSource);
-
-            obj['state'] = '';
             for (var j=0;j<Object.keys(data[state]).length;j++)
             {
-              if (data['US'][i].year == data[state][j].year) {
+              if (data['US'][i].year == data[state][j].year) 
                 obj['state'] = data[state][j].alldrug;
-
-                if (showPercent)
-                  obj['state_pct'] = data[state][j].alldrug;
-
-                if (showCount)
-                  obj['state_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthlyNonUS('alldrug', data['US'][i].year, state, stateData) : AccessibilityFunctions.getCountYearlyNonUS('alldrug', data['US'][i].year, state, stateData);
-              }
             }
           }
 
           if (currentDrug == 'benzodiazepine') {
             obj['Overall'] = data['US'][i].benzodiazepine;
 
-            if (showPercent)
-              obj['Overall_pct'] = data['US'][i].benzodiazepine;
-
-            obj['state'] = '';
-              for (var j=0;j<Object.keys(data[state]).length;j++)
-              {
-                if (data['US'][i].year == data[state][j].year) {
-                  obj['state'] = data[state][j].benzodiazepine;
-                  if (showPercent)
-                    obj['state_pct'] = data[state][j].benzodiazepine;
-                }
-              }
+            for (var j=0;j<Object.keys(data[state]).length;j++)
+            {
+              if (data['US'][i].year == data[state][j].year) 
+                obj['state'] = data[state][j].benzodiazepine;
+            }
           }
 
           if (currentDrug == 'cocaine') {
             obj['Overall'] = data['US'][i].cocaine;
-            if (showPercent)
-              obj['Overall_pct'] = data['US'][i].cocaine;
 
-            obj['state'] = '';
-              for (var j=0;j<Object.keys(data[state]).length;j++)
-              {
-                if (data['US'][i].year == data[state][j].year) {
-                  obj['state'] = data[state][j].cocaine;
-                  if (showPercent)
-                    obj['state_pct'] = data[state][j].cocaine;
-                }
-              }
+            for (var j=0;j<Object.keys(data[state]).length;j++)
+            {
+              if (data['US'][i].year == data[state][j].year) 
+                obj['state'] = data[state][j].cocaine;
+            }
           }
 
           if (currentDrug == 'fentanyl') {
-              obj['Overall'] = data['US'][i].fentanyl;
-              if (showPercent)
-                obj['Overall_pct'] = data['US'][i].fentanyl;
+            obj['Overall'] = data['US'][i].fentanyl;
 
-              obj['state'] = '';
-              for (var j=0;j<Object.keys(data[state]).length;j++)
-              {
-                if (data['US'][i].year == data[state][j].year) {
-                  obj['state'] = data[state][j].fentanyl;
-                  if (showPercent)
-                    obj['state_pct'] = data[state][j].fentanyl;
-                }
-              }
+            for (var j=0;j<Object.keys(data[state]).length;j++)
+            {
+              if (data['US'][i].year == data[state][j].year) 
+                obj['state'] = data[state][j].fentanyl;
+            }
           }
 
           if (currentDrug == 'heroin') {
-              obj['Overall'] = data['US'][i].heroin;
-              if (showPercent)
-                obj['Overall_pct'] = data['US'][i].heroin;
+            obj['Overall'] = data['US'][i].heroin;
 
-              obj['state'] = '';
-              for (var j=0;j<Object.keys(data[state]).length;j++)
-              {
-                if (data['US'][i].year == data[state][j].year) {
-                  obj['state'] = data[state][j].heroin;
-                  if (showPercent)
-                    obj['state_pct'] = data[state][j].heroin;
-                }
-              }
+            for (var j=0;j<Object.keys(data[state]).length;j++)
+            {
+              if (data['US'][i].year == data[state][j].year) 
+                obj['state'] = data[state][j].heroin;
+            }
           }
 
           if (currentDrug == 'methamphetamine') {
             obj['Overall'] = data['US'][i].methamphetamine;
-            if (showPercent)
-                obj['Overall_pct'] = data['US'][i].methamphetamine;
 
-            obj['state'] = '';
-              for (var j=0;j<Object.keys(data[state]).length;j++)
-              {
-                if (data['US'][i].year == data[state][j].year) {
-                  obj['state'] = data[state][j].methamphetamine;
-                  if (showPercent)
-                    obj['state_pct'] = data[state][j].methamphetamine;
-                }
-              }
+            for (var j=0;j<Object.keys(data[state]).length;j++)
+            {
+              if (data['US'][i].year == data[state][j].year) 
+                obj['state'] = data[state][j].methamphetamine;
+            }
           }
 
           if (currentDrug == 'opioid') {
-             obj['Overall'] = data['US'][i].opioid;
-             if (showPercent)
-                obj['Overall_pct'] = data['US'][i].opioid;
+            obj['Overall'] = data['US'][i].opioid;
 
-              obj['state'] = '';
-              for (var j=0;j<Object.keys(data[state]).length;j++)
-              {
-                if (data['US'][i].year == data[state][j].year) {
-                  obj['state'] = data[state][j].opioid;
-                  if (showPercent)
-                    obj['state_pct'] = data[state][j].opioid;
-                }
-              }
+            for (var j=0;j<Object.keys(data[state]).length;j++)
+            {
+              if (data['US'][i].year == data[state][j].year) 
+                obj['state'] = data[state][j].opioid;
+            }
           }
 
           if (currentDrug == 'stimulant') {
-             obj['Overall'] = data['US'][i].stimulant;
-             if (showPercent)
-                obj['Overall_pct'] = data['US'][i].stimulant;
+            obj['Overall'] = data['US'][i].stimulant;
 
-              obj['state'] = '';
-              for (var j=0;j<Object.keys(data[state]).length;j++)
-              {
-                if (data['US'][i].year == data[state][j].year) {
-                  obj['state'] = data[state][j].stimulant;
-                  if (showPercent)
-                    obj['state_pct'] = data[state][j].stimulant;
-                }
-              }
+            for (var j=0;j<Object.keys(data[state]).length;j++)
+            {
+              if (data['US'][i].year == data[state][j].year) 
+                obj['state'] = data[state][j].stimulant;
+            }
+          }
+
+          if (showPercent)
+            obj['Overall_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, 'US', changePrecValues);
+
+          if (showPercent)
+            obj['state_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, state, changePrecValues);
+
+          if (showCount) {
+              obj['Overall_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly(currentDrug, data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly(currentDrug, data['US'][i].year, state, countsDataYearly);
+              obj['state_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthlyNonUS(currentDrug, data['US'][i].year, state, stateData, currentDataSource) : AccessibilityFunctions.getCountYearlyNonUS(currentDrug, data['US'][i].year, state, stateData, currentDataSource);
           }
 
           let monyr = currentTimeframe == 'Monthly' ? (UtilityFunctions.getMonthName(String(Number(data['US'][i].year.substring(4)))) + ' ' + data['US'][i].year.substring(0,4)) : data['US'][i].year;
           myData[monyr] = obj;
         }
       }
-            
+
       return myData;
   
     },  

--- a/src/components/DataTable508.js
+++ b/src/components/DataTable508.js
@@ -2,7 +2,10 @@ import '../css/DataTable508.css';
 
 function DataTable508(params) {
 
-  const { data, rates, cutoffData, cutoffKey, highlight, xAxisKey, suffixes, transforms, caption, customBackground, extraClasses, years, extraCols, width, colSpan, isSmallViewport, hdr, supScript, noSort } = params;
+  const { data, rates, cutoffData, cutoffKey, highlight, xAxisKey, suffixes, transforms, caption, customBackground, extraClasses, years, extraCols, width, colSpan, colSpan2, isSmallViewport, hdr, supScript, noSort } = params;
+
+  if (data == null || data === undefined || Object.keys(data).length == 0)
+    return;
 
   const labelOverrides = params.labelOverrides || {};
 
@@ -91,6 +94,7 @@ function DataTable508(params) {
             <tr>
               <th className={'keepSticky'} scope="col" rowspan="2">{labelOverrides[xAxisKey] || formatLabel(xAxisKey)}</th>
               {colSpan != null && <th key={'abcd'} scope="col" colspan={colSpan} className={'centerAlign'}>{hdr != null ? hdr : 'Rate per 100,000 persons'}{hdr == null ? <sup>5</sup> : ''}</th>}
+              {colSpan2 != null && <th key={'abcde'} scope="col" colspan={colSpan2} className={'centerAlign'}>{hdr != null ? hdr : 'Count'}</th>}
             </tr>
             <tr>
               {!isArray && [data].map((d, index) => 

--- a/src/components/DataTable508.js
+++ b/src/components/DataTable508.js
@@ -2,13 +2,13 @@ import '../css/DataTable508.css';
 
 function DataTable508(params) {
 
-  const { data, rates, cutoffData, cutoffKey, highlight, xAxisKey, suffixes, transforms, caption, customBackground, extraClasses, years, extraCols, width, colSpan, isSmallViewport, hdr, supScript } = params;
+  const { data, rates, cutoffData, cutoffKey, highlight, xAxisKey, suffixes, transforms, caption, customBackground, extraClasses, years, extraCols, width, colSpan, isSmallViewport, hdr, supScript, noSort } = params;
 
   const labelOverrides = params.labelOverrides || {};
 
   const isArray = Array.isArray(data);
 
-  const keys = (isArray ? Object.keys(data[0]) : Object.keys(data).sort((a,b) => {
+  const keys = (isArray ? Object.keys(data[0]) : noSort ? Object.keys(data) : Object.keys(data).sort((a,b) => {
     if(a === 'Overall') return -1;
     if(b === 'Overall') return 1;
     return a < b ? -1 : 1;

--- a/src/components/LineChart.js
+++ b/src/components/LineChart.js
@@ -216,9 +216,9 @@ function LineChart({ params }) {
   
   const yScaleDomainPeriod = (UtilityFunctions.calculateYScaleDomain(filteredData, currentDrug, selectedDrugs, currentState) * 1.2);
 
-  const currentStaterate = stateNames[currentState] + ' rate'
+  const currentStaterate = stateNames[currentState];
   const currentStatePctChange = stateNames[currentState] + ' %change in rate'
-  const currentStateCnt = stateNames[currentState] + ' count'
+  const currentStateCnt = stateNames[currentState];
 
   useEffect(() => {
     markYearsForTicks();
@@ -1130,25 +1130,25 @@ function LineChart({ params }) {
             'state_pct' : currentStatePctChange,
             'Year/Month': currentTimeframe == 'Monthly' ? 'Month and Year' : 'Year',
           } : showCount ? {
-            'alldrug': 'All Drugs rate',
-            'benzodiazepine': 'Benzodiazepine rate',
-            'cocaine': 'Cocaine rate',
-            'heroin': 'Heroin rate',
-            'methamphetamine': 'Methamphetamine rate',
-            'opioid': 'All Opioids rate',
-            'stimulant': 'All Stimulants rate',
-            'fentanyl': 'Fentanyl rate',
-            'Overall': 'Overall rate',
+            'alldrug': 'All Drugs',
+            'benzodiazepine': 'Benzodiazepine',
+            'cocaine': 'Cocaine',
+            'heroin': 'Heroin',
+            'methamphetamine': 'Methamphetamine',
+            'opioid': 'All Opioids',
+            'stimulant': 'All Stimulants',
+            'fentanyl': 'Fentanyl',
+            'Overall': 'Overall',
             'state' : currentStaterate,
-            'alldrug_cnt': 'All Drugs count',
-            'benzodiazepine_cnt': 'Benzodiazepine count',
-            'cocaine_cnt': 'Cocaine count',
-            'heroin_cnt': 'Heroin count',
-            'methamphetamine_cnt': 'Methamphetamine count',
-            'opioid_cnt': 'All Opioids count',
-            'stimulant_cnt': 'All Stimulants count',
-            'fentanyl_cnt': 'Fentanyl count',
-            'Overall_cnt': 'Overall count',
+            'alldrug_cnt': 'All Drugs',
+            'benzodiazepine_cnt': 'Benzodiazepine',
+            'cocaine_cnt': 'Cocaine',
+            'heroin_cnt': 'Heroin',
+            'methamphetamine_cnt': 'Methamphetamine',
+            'opioid_cnt': 'All Opioids',
+            'stimulant_cnt': 'All Stimulants',
+            'fentanyl_cnt': 'Fentanyl',
+            'Overall_cnt': 'Overall',
             'state_cnt' : currentStateCnt,
           } : {
             'alldrug': 'All Drugs',
@@ -1159,7 +1159,7 @@ function LineChart({ params }) {
             'opioid': 'All Opioids',
             'stimulant': 'All Stimulants',
             'fentanyl': 'Fentanyl',
-            'Overall': 'Overall rate',
+            'Overall': 'Overall',
             'state' : currentStaterate,
             'Year/Month': currentTimeframe == 'Monthly' ? 'Month and Year' : 'Year',
           }}

--- a/src/components/LineChart.js
+++ b/src/components/LineChart.js
@@ -728,6 +728,14 @@ function LineChart({ params }) {
     return sortedToolTips;
   }
   
+  const get2024FootNote = (yr, str) => {
+    if (String(yr).substring(0,4) == '2024' && str == 'Data not available' )
+      return '<sup>§</sup>';
+    else
+      return '';
+  }
+
+  
   const buildToolTipValues = (sectionWidth, sectionWidthHalf) => {
     return (
       <Fragment>
@@ -740,7 +748,7 @@ function LineChart({ params }) {
               var tooltipValues = [];
               if (!currentDrugOnly) {
                 tooltipValues.push(`<p><strong class=${currentDrug + 'ToolTip'}>` + drugOptions[currentDrug].titleForDropDown + ` Overall Rate</strong>: ${d[currentDrug]} (${numStates} Jurisdictions)</p>`);
-                tooltipValues.push(`<p><strong class=${currentDrug + 'ToolTip'}>` + drugOptions[currentDrug].titleForDropDown + ` Overall Count</strong>: ${cntC} (${numStates} Jurisdictions)</p>`);
+                tooltipValues.push(`<p><strong class=${currentDrug + 'ToolTip'}>` + drugOptions[currentDrug].titleForDropDown + ` Overall Count</strong>: ${cntC} (${numStates} Jurisdictions)` + get2024FootNote(d['year'], cntC) + `</p>`);
               }
 
               if (inp.selectedDrugs.length > 0) {
@@ -748,7 +756,7 @@ function LineChart({ params }) {
                     let cntS = getCountforDrug(inp.selectedDrugs[i], 'US', currentTimeframe == 'Annual' ? d['year'] : (!isPeriod ? d['month'] : inp.monthNamesPeriod[d['index']]));
                     if (!inp.selectedDrugs[i].includes(currentDrug)){
                       tooltipValues.push(!currentDrugOnly ? `<p><strong class=${inp.selectedDrugs[i] + 'ToolTip'}>` + drugOptions[inp.selectedDrugs[i]].titleForDropDown + ` Overall Rate</strong>: ${d[inp.selectedDrugs[i]]} (${numStates} Jurisdictions)</p>` : null);
-                      tooltipValues.push(!currentDrugOnly ? `<p><strong class=${inp.selectedDrugs[i] + 'ToolTip'}>` + drugOptions[inp.selectedDrugs[i]].titleForDropDown + ` Overall Count</strong>: ${cntS} (${numStates} Jurisdictions)</p>` : null);
+                      tooltipValues.push(!currentDrugOnly ? `<p><strong class=${inp.selectedDrugs[i] + 'ToolTip'}>` + drugOptions[inp.selectedDrugs[i]].titleForDropDown + ` Overall Count</strong>: ${cntS} (${numStates} Jurisdictions)` + get2024FootNote(d['year'], cntS) + `</p>` : null);
                     }
                   }
               }
@@ -1141,6 +1149,7 @@ function LineChart({ params }) {
           colSpan={!showPercent ? ((currentState == 'US' ? (!showPercent ? selectedDrugs.length : (selectedDrugs.length * 2)) : (!showPercent ? 2: 4))) : null}
           isSmallViewport={specs['isSmallViewport']}
           supScript={showPercent ?'§': ''}
+          noSort={true}
         />
         {(currentDrug == 'fentanyl' || selectedDrugs.includes('fentanyl')) &&
           <table style={{width: '100%'}}>

--- a/src/components/LineChart.js
+++ b/src/components/LineChart.js
@@ -1168,7 +1168,8 @@ function LineChart({ params }) {
             rate: num => UtilityFunctions.toFixed(num)
           }}
           width={width}
-          colSpan={(!showPercent && !showCount) ? ((currentState == 'US' ? ((!showPercent && !showCount) ? selectedDrugs.length : (selectedDrugs.length * 2)) : ((!showPercent && !showCount) ? 2: 4))) : null}
+          colSpan={(showPercent) ? ((currentState == 'US' ? (showPercent ? (selectedDrugs.length * 2) : selectedDrugs.length) : ((showPercent) ? 4: 2))) : (currentState == 'US' ? selectedDrugs.length : 2)}
+          colSpan2={(showCount) ? ((currentState == 'US' ? (showCount ? (selectedDrugs.length * 2) : selectedDrugs.length) : ((showCount) ? 4: 2))) : null}
           isSmallViewport={specs['isSmallViewport']}
           supScript={showPercent ?'§': ''}
           noSort={true}

--- a/src/components/LineChart.js
+++ b/src/components/LineChart.js
@@ -660,13 +660,13 @@ function LineChart({ params }) {
       for (var i in selectedDrugs) {
         if (selectedDrugs[i].includes(currentDrug)) {
           let cnt = getCountforDrug(selectedDrugs[i], parmState, val);
-          leftCntStr = leftCntStr + `<span class=${selectedDrugs[i] + 'ToolTip'}` + '>' + (isNaN(cnt) ? getText(cnt) : cnt) + '</span></br>'
+          leftCntStr = leftCntStr + `<span class=${selectedDrugs[i] + 'ToolTip'}` + '>' + (isNaN(cnt) ? (getText(cnt) + (checkIf2024(val) ? '<sup>§</sup>' : '')) : cnt) + '</span></br>'
         }
       }
     }
     else {
       let cnt = getCountforDrug(currentDrug, parmState, val);
-      leftCntStr = leftCntStr + `<span class=${currentDrug + 'ToolTip'}` + '>' + (isNaN(cnt) ? getText(cnt) : cnt) + '</span></br>'
+      leftCntStr = leftCntStr + `<span class=${currentDrug + 'ToolTip'}` + '>' + (isNaN(cnt) ? (getText(cnt) + (checkIf2024(val) ? '<sup>§</sup>' : '')) : cnt) + '</span></br>'
     }
     return leftCntStr;
   }
@@ -736,6 +736,28 @@ function LineChart({ params }) {
       return '';
   }
 
+  const checkIf2024 = (val) => {
+
+    if (currentTimeframe == 'Annual')
+    {
+      if (val == '2024')
+        return true;
+    }
+    else
+    {
+      if (isPeriod) {
+        if (val.includes('2024'))
+          return true;
+      }
+      else
+      {
+          if ((val >= 1 || val <= 12) && currentYear == '2024')
+            return true;
+      }
+    }
+    
+    return false;
+  }
   
   const buildToolTipValues = (sectionWidth, sectionWidthHalf) => {
     return (

--- a/src/components/LineChart.js
+++ b/src/components/LineChart.js
@@ -200,7 +200,7 @@ const getFilteredDataPeriod = (data, currentDataSource, currentState, lookupPeri
 
 function LineChart({ params }) {
 
-  const { data, monthNames, stateNames, drugOptions, currentTimeframe, currentDataSource, currentDrug, currentState, currentYear: currentYearUntyped, currentMonth, width, stateDropdownOptions, lookupPeriodStartYear, lookupPeriodStartMonth, lookupPeriodEndYear, lookupPeriodEndMonth, showLabels, showPercent, isPeriod, currentDrugOnly, supportedYears, selectedDrugs, accessible } = params;
+  const { data, monthNames, stateNames, drugOptions, currentTimeframe, currentDataSource, currentDrug, currentState, currentYear: currentYearUntyped, currentMonth, width, stateDropdownOptions, lookupPeriodStartYear, lookupPeriodStartMonth, lookupPeriodEndYear, lookupPeriodEndMonth, showLabels, showPercent, showCount, isPeriod, currentDrugOnly, supportedYears, selectedDrugs, accessible } = params;
 
   const currentYear = parseInt(currentYearUntyped);
 
@@ -218,6 +218,7 @@ function LineChart({ params }) {
 
   const currentStaterate = stateNames[currentState] + ' rate'
   const currentStatePctChange = stateNames[currentState] + ' %change in rate'
+  const currentStateCnt = stateNames[currentState] + ' count'
 
   useEffect(() => {
     markYearsForTicks();
@@ -1105,20 +1106,8 @@ function LineChart({ params }) {
     {accessible ? (
         <>
         <DataTable508
-          data={AccessibilityFunctions.generateLineChartData(filteredData, currentDrug, selectedDrugs, currentState, stateNames, currentTimeframe, showPercent, changePrecValues)}
-          labelOverrides={ !showPercent ? {
-            'alldrug': 'All Drugs',
-            'benzodiazepine': 'Benzodiazepine',
-            'cocaine': 'Cocaine',
-            'heroin': 'Heroin',
-            'methamphetamine': 'Methamphetamine',
-            'opioid': 'All Opioids',
-            'stimulant': 'All Stimulants',
-            'fentanyl': 'Fentanyl',
-            'Overall': 'Overall rate',
-            'state' : currentStaterate,
-            'Year/Month': currentTimeframe == 'Monthly' ? 'Month and Year' : 'Year',
-          } : {
+          data={AccessibilityFunctions.generateLineChartData(data.state, filteredData, currentDataSource, countsDataYearly, countsDataMonthly, currentDrug, selectedDrugs, currentState, stateNames, currentTimeframe, showPercent, showCount, changePrecValues)}
+          labelOverrides={showPercent ? {
             'alldrug': 'All Drugs rate',
             'benzodiazepine': 'Benzodiazepine rate',
             'cocaine': 'Cocaine rate',
@@ -1140,13 +1129,46 @@ function LineChart({ params }) {
             'state' : currentStaterate,
             'state_pct' : currentStatePctChange,
             'Year/Month': currentTimeframe == 'Monthly' ? 'Month and Year' : 'Year',
+          } : showCount ? {
+            'alldrug': 'All Drugs rate',
+            'benzodiazepine': 'Benzodiazepine rate',
+            'cocaine': 'Cocaine rate',
+            'heroin': 'Heroin rate',
+            'methamphetamine': 'Methamphetamine rate',
+            'opioid': 'All Opioids rate',
+            'stimulant': 'All Stimulants rate',
+            'fentanyl': 'Fentanyl rate',
+            'Overall': 'Overall rate',
+            'state' : currentStaterate,
+            'alldrug_cnt': 'All Drugs count',
+            'benzodiazepine_cnt': 'Benzodiazepine count',
+            'cocaine_cnt': 'Cocaine count',
+            'heroin_cnt': 'Heroin count',
+            'methamphetamine_cnt': 'Methamphetamine count',
+            'opioid_cnt': 'All Opioids count',
+            'stimulant_cnt': 'All Stimulants count',
+            'fentanyl_cnt': 'Fentanyl count',
+            'Overall_cnt': 'Overall count',
+            'state_cnt' : currentStateCnt,
+          } : {
+            'alldrug': 'All Drugs',
+            'benzodiazepine': 'Benzodiazepine',
+            'cocaine': 'Cocaine',
+            'heroin': 'Heroin',
+            'methamphetamine': 'Methamphetamine',
+            'opioid': 'All Opioids',
+            'stimulant': 'All Stimulants',
+            'fentanyl': 'Fentanyl',
+            'Overall': 'Overall rate',
+            'state' : currentStaterate,
+            'Year/Month': currentTimeframe == 'Monthly' ? 'Month and Year' : 'Year',
           }}
           xAxisKey={'Year/Month'}
           transforms={{
             rate: num => UtilityFunctions.toFixed(num)
           }}
           width={width}
-          colSpan={!showPercent ? ((currentState == 'US' ? (!showPercent ? selectedDrugs.length : (selectedDrugs.length * 2)) : (!showPercent ? 2: 4))) : null}
+          colSpan={(!showPercent && !showCount) ? ((currentState == 'US' ? ((!showPercent && !showCount) ? selectedDrugs.length : (selectedDrugs.length * 2)) : ((!showPercent && !showCount) ? 2: 4))) : null}
           isSmallViewport={specs['isSmallViewport']}
           supScript={showPercent ?'§': ''}
           noSort={true}

--- a/src/components/SexAgeCharts.js
+++ b/src/components/SexAgeCharts.js
@@ -107,6 +107,7 @@ function SexAgeCharts(params) {
           colSpan={!isSmallViewport ? 2 : null}
           isSmallViewport={isSmallViewport}
           hdr={currentDataType == 'count' ? 'Count' : null}
+          noSort={true}
         />
         </>        
       ) : (

--- a/src/components/StateChart.js
+++ b/src/components/StateChart.js
@@ -186,6 +186,7 @@ function StateChart(params) {
             rate: num => UtilityFunctions.toFixed(num)
           }}
            width={width}
+           noSort={false}
         />
         </>        
       ) : (

--- a/src/components/UsaMap.js
+++ b/src/components/UsaMap.js
@@ -240,6 +240,7 @@ const UsaMap = ({ params }) => {
               rate: num => (isNaN(num) ? num : num)
             }}
               width={width}
+              noSort={false}
           />
           </>        
         ) : (

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -82,6 +82,14 @@ line-height: 1;
 background-color: transparent;
 }
 
+button-toggle {
+padding: 0.75em 1em;
+border-radius: 0;
+line-height: 1;
+background-color: transparent;
+height: inherit!important;
+}
+
 button * {
 pointer-events: none;
 }
@@ -196,6 +204,36 @@ color: #fff;
 font-family: var(--fonts-nunito);
 padding: .75em 18px;
 margin-bottom: 1em;
+
+&.sub {
+padding: .2em 0.5em;
+}
+
+span {
+font-size: 1.2em;
+font-weight: bold;
+}
+
+h2 {
+font-size: 2.1em;
+margin: 0;
+padding: '0';
+display: 'block';
+font-weight: 'bold';
+
+&.sub {
+font-size: '1em';
+}
+// font-family: "Open Sans", apple-system, blinkmacsystemfont, "Segoe UI", "Helvetica Neue", arial, sans-serif;
+}
+}
+
+.data-bite-header-toggle {
+color: #fff;
+font-family: var(--fonts-nunito);
+//padding: .75em 18px;
+margin-bottom: 4px!important;
+padding-bottom: 0px!important;
 
 &.sub {
 padding: .2em 0.5em;
@@ -654,6 +692,155 @@ margin-right: 5px;
 }
 }
 }
+
+.datatable-container-header {
+//z-index: 10;
+position: relative;
+padding: 0px!important;
+margin: 0px!important;
+
+&:before {
+content: "";
+display: block;
+height: $gbl-padding;
+}
+
+h2,
+.h2 {
+display: grid;
+align-items: center;
+grid-template-columns: 1fr 10px;
+gap: 10px;
+width: 100%;
+margin: 0;
+color: rgb(255, 255, 255);
+font-size: 1.4rem;
+// font-family: sans-serif;
+font-family: var(--fonts-nunito);
+font-weight: 300;
+line-height: 1.3;
+text-align: left;
+//padding: 0.5em $gbl-padding;
+cursor: pointer;
+position: relative;
+
+span {
+position: absolute;
+right: $gbl-padding;
+font-size: 24px;
+font-weight: bold;
+top: 10px;
+}
+}
+
+.datatable-body {
+
+font-size: .85em;
+padding: $gbl-padding 0;
+
+@include r($lg) {
+font-size: inherit;
+padding: $gbl-padding;
+}
+
+p {
+margin-bottom: $gbl-padding;
+}
+
+ol {
+margin-left: $gbl-padding;
+
+li {
+margin-bottom: $gbl-padding;
+}
+}
+
+ul {
+list-style-type:circle;
+margin-left: $gbl-padding;
+
+li {
+margin-bottom: $gbl-padding;
+}
+}
+
+.main-data-table-container {
+overflow-x: auto;
+
+.main-data-table {
+border-collapse: collapse;
+margin-bottom: $gbl-padding;
+font-size: .75em;
+
+@include r($sm) {
+font-size: .85em;
+}
+
+caption {
+color: black;
+text-align: left;
+margin-bottom: 1em;
+caption-side: top;
+font-weight: bold;
+font-size: medium;
+}
+
+tr {
+&.state-header {
+th {
+color: #000 !important;
+}
+}
+
+th {
+position: relative;
+border: 1px solid #dee2e6;
+padding: 0.3rem 0.5rem;
+text-align: left;
+color: white;
+cursor: pointer;
+
+&.sorting::before {
+content: ">";
+position: absolute;
+right: 1em;
+font-size: large;
+font-weight: bold;
+top: 0.5em;
+transform: rotate(90deg);
+pointer-events: none;
+}
+
+&.sorting.asc::before {
+transform: rotate(-90deg);
+}
+
+button {
+width: 100%;
+border: 0;
+}
+}
+
+td {
+border: 1px solid #dee2e6;
+padding: 0.3rem 0.5rem;
+
+.datatable-hex-container {
+display: flex;
+justify-items: flex-start;
+
+.datatable-hex {
+width: 18px;
+margin-right: 5px;
+}
+}
+}
+}
+}
+}
+}
+}
+
 }
 
 .colorRed
@@ -667,6 +854,12 @@ font-size: 22px!important;
 
 .h2, h2 {
 font-size: 1.60rem!important;
+}
+
+.h2-toggle {
+font-size: 1.60rem!important;
+padding: 0px!important;
+margin: 0px!important;
 }
 
 #noBullets {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -232,7 +232,7 @@ font-size: '1em';
 color: #fff;
 font-family: var(--fonts-nunito);
 //padding: .75em 18px;
-margin-bottom: 4px!important;
+margin-bottom: 6px!important;
 padding-bottom: 0px!important;
 
 &.sub {
@@ -242,6 +242,10 @@ padding: .2em 0.5em;
 span {
 font-size: 1.2em;
 font-weight: bold;
+}
+
+sup {
+   font-size: 0.5em; 
 }
 
 h2 {
@@ -1204,7 +1208,7 @@ transition: All 0.3s ease;
 .toggleB {
 position: relative;
 display: block;
-width: 140px;
+width: 120px;
 height: 30px;
 padding: 3px;
 margin: auto;
@@ -1274,7 +1278,7 @@ width: 16px;
 height: 16px;
 }
 .toggleB-input:checked~.toggleB-handle {
-left: 107.5px;
+left: 87.5px;
 box-shadow: -1px 1px 5px 
 rgba(0, 0, 0, 0.2);
 }


### PR DESCRIPTION
IDEA-D 525: On both the main and accessibility DIS pages, the § footnote symbol seems to be missing (not referenced) from the banner at top of regular DIS dashboard. It should be after the "Data not available" text, as noted in marked-up screenshot below (in red). This should appear when the year 2024 is selected in drop-down menu (for either monthly or annual data).
 
IDEA-D 526: For both regular and accessibility DIS dashboard views: could there be a comma for the 1,000 separator in the top banner (counts)? See edited screenshot/example below in red-- this is relevant any time a value is >1000.
 
IDEA-D 527: In this table, please ensure the months are sequential (follow calendar year) rather than alphabetical.
 
IDEA-D 528: Below table: is there an option to vertically collapse this table to make scrolling easier.
 
IDEA-D 529: When the county table does NOT show (i.e., when something other than ED visits and all-drug overdoses is selected), there seems to be some remaining/leftover footnotes from the county ED data that still appear right above the main footnotes section (see text in the circle).
 
IDEA-D 530: One more thing on interactive DOSE-DIS dashboard. In trend line figure, I could not find a reference to the § footnote. I think the best place I can think of to reference it is in the hover-over box here  (see screenshot, hover-over box, next to "Data not available", where I added it in red).
 
IDEA-D 531: Have an additional toggle to show counts (e.g., "Count On") that would then add an additional column to the table, as shown roughly in the screenshot below.

Thanks.