### PR TITLE
Sravan dose discharge 12082025 0900

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1581,8 +1581,12 @@ export default function App(params) {
                     setCurrentState(param);
                     if (param !== 'US')
                       setOnlyCurrentDrug(true);
-                    else
+                    else {
                       setOnlyCurrentDrug(false);
+                      setCountToggle(false)
+                      setOverallToggle(false)
+                      setCompareToggle(false)
+                    }
 
                     setStateDropdownOptionsCompare(getSupportedStatesForCompare(stateDropdownOptions, param))
                   },

--- a/src/App.js
+++ b/src/App.js
@@ -723,8 +723,8 @@ export default function App(params) {
                     }
                     {accessible &&
                       <div style={{ float: 'left' }}>
-                        <label class="toggleB" title={'Toggle to see count.'}>
-                          <input id="toggleBCount" class="toggleB-input" type="checkbox" checked={showCount} disabled={showPercent}
+                        <label class="toggleD" title={'Toggle to see count.'}>
+                          <input id="toggleDCount" class="toggleD-input" type="checkbox" checked={showCount} disabled={showPercent}
                             onChange={(e) => {
                               if (e.target.checked) {
                                 setCountToggle(true)
@@ -733,10 +733,10 @@ export default function App(params) {
                                 setCountToggle(false)
                               }
                             }} />
-                          <span class="toggleB-label" data-off="Count Off"
+                          <span class="toggleD-label" data-off="Count Off"
                             data-on="Count On">
                           </span>
-                          <span class="toggleB-handle"></span>
+                          <span class="toggleD-handle"></span>
                         </label>
                       </div>
                     }
@@ -854,8 +854,8 @@ export default function App(params) {
                   }
                   {accessible &&
                       <div style={{ float: 'left' }}>
-                        <label class="toggleB" title={'Toggle to see count.'}>
-                          <input id="toggleBCount" class="toggleB-input" type="checkbox" checked={showCount} disabled={showPercent}
+                        <label class="toggleD" title={'Toggle to see count.'}>
+                          <input id="toggleDCount" class="toggleD-input" type="checkbox" checked={showCount} disabled={showPercent}
                             onChange={(e) => {
                               if (e.target.checked) {
                                 setCountToggle(true)
@@ -864,10 +864,10 @@ export default function App(params) {
                                 setCountToggle(false)
                               }
                             }} />
-                          <span class="toggleB-label" data-off="Count Off"
+                          <span class="toggleD-label" data-off="Count Off"
                             data-on="Count On">
                           </span>
-                          <span class="toggleB-handle"></span>
+                          <span class="toggleD-handle"></span>
                         </label>
                       </div>
                   }
@@ -1579,18 +1579,13 @@ export default function App(params) {
                   value: currentState,
                   onChange: (param) => {
                     setCurrentState(param);
-                    if (param !== 'US')
-                      setOnlyCurrentDrug(true);
-                    else {
-                      setOnlyCurrentDrug(false);
-                      setCountToggle(false)
-                      setOverallToggle(false)
-                      setCompareToggle(false)
-                    }
+                    setOnlyCurrentDrug(false);
+                    setCountToggle(false);
+                    setOverallToggle(false);
+                    setCompareToggle(false);
 
                     setStateDropdownOptionsCompare(getSupportedStatesForCompare(stateDropdownOptions, param))
                   },
-
 
                   options: stateDropdownOptions?.sort((a, b) => {
                     if (a === 'US') return -1;

--- a/src/App.js
+++ b/src/App.js
@@ -744,7 +744,6 @@ export default function App(params) {
                 </tr>
               </table>
             </td>
-
           </tr>
           <tr>
             <td colSpan='2' class="drugsDivTop" style={{ textAlign: 'left', verticalAlign: 'top', paddingLeft: '15px' }}>
@@ -756,55 +755,130 @@ export default function App(params) {
               </td>
             }
           </tr>
-
           </table>
         }
         {isSmallViewport && 
           <table style={{ tableLayout: 'fixed', display: 'block', width: '100%' }}>
           <tr>
             <td colSpan='2'>
-                      <label className="subLabel">Make a selection to change the line graph&nbsp;&nbsp;</label>
+                  {!showOverall && !showCompare && <label className="subLabel">Make a selection to change the line graph&nbsp;&nbsp;</label>}
+                  {showCompare && <label className="subLabel">Select a jurisdiction to compare:&nbsp;&nbsp;</label>}
             </td>
           </tr>
           <tr>
-                  <td style={{ width: '50%!important', verticalAlign: 'top', textAlign: 'left' }}>
-                        <label title="Check to select all drugs.">
-                          <input id="toggleSelectAll" type="checkbox" checked={selectAllFlag}
+              <td style={{ width: '50%!important', verticalAlign: 'top', textAlign: 'left', paddingLeft: '10px' }}>
+                    {!showOverall && !showCompare && 
+                  <div>
+                    <label title="Check to select all drugs.">
+                      <input id="toggleSelectAll" type="checkbox" checked={selectAllFlag}
+                        onChange={(e) => {
+                          if (e.target.checked) {
+                            setCurrentDrug(currentDrug);
+                            selectAllDrugs();
+                            setDeselectAllFlag(false);
+                            setSelectAllFlag(true);
+                          }
+                          else {
+                            setCurrentDrug(currentDrug);
+                            setselectedDrugs([currentDrug])
+                            setSelectAllFlag(false);
+                          }
+                        }} /> Select All
+                    </label>
+                </div>
+                }
+                {showCompare && 
+                  <div>
+                      <Select params={{
+                        key: 'jurisdiction',
+                        label: '',
+                        noSelectPrefix: true,
+                        value: compareState,
+                        onChange: (param) => {
+                          setCompareState(param);
+                          setOnlyCurrentDrug(true);
+                        },
+                        options: stateDropdownOptionsCompare,
+                        optionLabel: (key) => key != 'US' ? stateNames[key] : stateNames[key] + ' (' + (Object.keys(stateDropdownOptions).length - 1) + ' Jurisdictions)'
+                      }} />
+                  </div>
+                  }
+              </td>
+              <td style={{ width: '50%', verticalAlign: 'top', textAlign: 'left' }}>
+                {!showOverall && !showCompare &&
+                <div>
+                    <label title="Check to clear all drugs, except current drug.">
+                      <input id="toggleClearAll" type="checkbox" checked={deselectAllFlag}
+                        onChange={(e) => {
+                          if (e.target.checked) {
+                            setCurrentDrug(currentDrug);
+                            setselectedDrugs([currentDrug])
+                            setDeselectAllFlag(true);
+                            setSelectAllFlag(false);
+                          }
+                          else {
+                            setCurrentDrug(currentDrug);
+                            setselectedDrugs([currentDrug]);
+                            setDeselectAllFlag(false);
+                          }
+                        }} /> Clear All
+                    </label>
+                </div>
+                }
+              </td>
+          </tr>
+          <br></br>
+          <tr>
+            <td colSpan='2'>
+              <table>
+                <tr>
+                    <td style={{ width: '76%', textAlign: 'right' }}>
+                    {(currentState !== 'US') &&
+                      <div style={{ float: 'right' }}>
+                        <label class="toggleC" title={'Toggle to compare with a jurisdiction.'}>
+                          <input id="toggleCompare" class="toggleC-input" type="checkbox" checked={showCompare} disabled={showOverall}
                             onChange={(e) => {
                               if (e.target.checked) {
-                                setCurrentDrug(currentDrug);
-                                selectAllDrugs();
-                                setDeselectAllFlag(false);
-                                setSelectAllFlag(true);
+                                setCompareToggle(true)
+                                setCompareState(stateDropdownOptionsCompare[0]);
                               }
                               else {
-                                setCurrentDrug(currentDrug);
-                                setselectedDrugs([currentDrug])
-                                setSelectAllFlag(false);
+                                setCompareToggle(false)
+                                setCompareState('');
                               }
-                            }} /> Select All
+                            }} />
+                          <span class="toggleC-label" data-off="Compare Off"
+                            data-on="Compare On">
+                          </span>
+                          <span class="toggleC-handle"></span>
                         </label>
+                      </div>
+                    }
                   </td>
-                  <td style={{ width: '50%', verticalAlign: 'top', textAlign: 'left' }}>
-                    <div>
-                        <label title="Check to clear all drugs, except current drug.">
-                          <input id="toggleClearAll" type="checkbox" checked={deselectAllFlag}
+                  <td style={{ width: '28%', textAlign: 'left' }}>
+                    {(currentState !== 'US') &&
+                      <div style={{ float: 'right' }}>
+                        <label class="toggleB" title={'Toggle to compare with overall.'}>
+                          <input id="toggleOverall" class="toggleB-input" type="checkbox" checked={showOverall} disabled={showCompare}
                             onChange={(e) => {
                               if (e.target.checked) {
-                                setCurrentDrug(currentDrug);
-                                setselectedDrugs([currentDrug])
-                                setDeselectAllFlag(true);
-                                setSelectAllFlag(false);
+                                setOverallToggle(true)
                               }
                               else {
-                                setCurrentDrug(currentDrug);
-                                setselectedDrugs([currentDrug]);
-                                setDeselectAllFlag(false);
+                                setOverallToggle(false)
                               }
-                            }} /> Clear All
+                            }} />
+                          <span class="toggleB-label" data-off="Overall Off"
+                            data-on="Overall On">
+                          </span>
+                          <span class="toggleB-handle"></span>
                         </label>
-                    </div>
+                      </div>
+                    }
                   </td>
+                </tr>
+              </table>
+            </td>
           </tr>
           <br></br>
           <tr>
@@ -1635,7 +1709,7 @@ export default function App(params) {
             <div className="filters">
               <table>
                 <tr>
-                  <td>
+                  <td style={{ paddingTop: '6px' }}>
                     <div className={`dropdowns${isSmallViewport ? ' no-grid' : ''}`}>
                         <Select params={{
                           key: 'timeframe',
@@ -1666,7 +1740,7 @@ export default function App(params) {
                   </td>
                 </tr>
                 <tr>
-                  <td>
+                  <td style={{ paddingTop: '6px' }}>
                     <div className={`dropdowns${isSmallViewport ? ' no-grid' : ''}`}>
                         <Select params={{
                           key: 'year',
@@ -1702,7 +1776,7 @@ export default function App(params) {
                 </tr>
                 {(timeframeChanged && currentTimeframe == 'Monthly') &&
                 <tr>
-                  <td>
+                  <td style={{ paddingTop: '6px' }}>
                     <div className={`dropdowns${isSmallViewport ? ' no-grid' : ''}`}>
                         <Select params={{
                             key: 'month',
@@ -1728,7 +1802,7 @@ export default function App(params) {
                 </tr>
                 }
                 <tr>
-                  <td>
+                  <td style={{ paddingTop: '6px' }}>
                     <div className={`dropdowns${isSmallViewport ? ' no-grid' : ''}`}>
                       <Select params={{
                         key: 'jurisdiction',
@@ -1778,7 +1852,7 @@ export default function App(params) {
                   </td>
                 </tr>
                 <tr>
-                  <td>
+                  <td style={{ paddingTop: '6px' }}>
                     <div>
                       <select id="drug-select" value={currentDrug} onChange={(e) => { setDrug(e.target.value); }}>
                         <option value="alldrug">All Drugs</option>

--- a/src/App.js
+++ b/src/App.js
@@ -174,11 +174,13 @@ export default function App(params) {
 
   const [data, setData] = useState();
   const [stateDropdownOptions, setStateDropdownOptions] = useState(false);
+  const [stateDropdownOptionsCompare, setStateDropdownOptionsCompare] = useState(false);
   const [currentDataSource, setCurrentDataSource] = useState('ED');
   const [currentDrug, setCurrentDrug] = useState('alldrug');
   const [selectedDrugsState, setselectedDrugsState] = useState(['alldrug']);
   const [selectedDrugsSexAge, setselectedDrugsSexAge] = useState(['alldrug']);
   const [currentState, setCurrentState] = useState('US');
+  const [compareState, setCompareState] = useState('');
   const [currentTimeframe, setCurrentTimeframe] = useState('Annual');
   const [currentMonth, setCurrentMonth] = useState('1');
   const [currentYear, setCurrentYear] = useState(supportedYearsLatest);
@@ -191,12 +193,14 @@ export default function App(params) {
   const [currentDataType, setCurrentDataType] = useState('rate');
   const [showDatatable, setDatatable] = useState(false);
   const [showConsiderations, setConsiderations] = useState(false);
-  const [showFootnotes, setFootnotes] = useState(false);
   const [showStateTable, setStateTable] = useState(true);
   const [showMapTable, setMapTable] = useState(true);
+  const [showFootnotes, setFootnotes] = useState(false);
   const [showLabels, setLabelToggle] = useState(false);
   const [showPercent, setPercentToggle] = useState(false);
   const [showCount, setCountToggle] = useState(false);
+  const [showOverall, setOverallToggle] = useState(false);
+  const [showCompare, setCompareToggle] = useState(false);
   const [isPeriod, setPeriodToggle] = useState(false);
   const [selectAllFlag, setSelectAllFlag] = useState(false);
   const [deselectAllFlag, setDeselectAllFlag] = useState(false);
@@ -205,7 +209,6 @@ export default function App(params) {
   const [timeframeChanged, setTimeframeChanged] = useState(false);
   const [activeTab, setActiveTab] = useState(0);
   const { accessible } = params;
-
   const [width, setWidth] = useState(accessible ? 0 : 100);
   
   const dataPath = window.location.origin.includes('localhost') ? '/data/' : '/overdose-prevention/data-dashboards/dose-discharge-dashboard/data/';
@@ -215,7 +218,6 @@ export default function App(params) {
   const toggleFootnotes = () => setFootnotes(!showFootnotes);
   const toggleStateTable = () => setStateTable(!showStateTable);
   const toggleMapTable = () => setMapTable(!showMapTable);
-
 
   const isSmallViewport = width < viewportCutoffSmall;
 
@@ -551,73 +553,135 @@ export default function App(params) {
     )
   }
 
+  const getSupportedStatesForCompare = (sts, cst) => {
+    return sts.filter(item => item !== cst).filter(item => item !== 'US');
+  }
+
   const getToggleControls = () => {
     return (
       <Fragment>
         {!isSmallViewport && 
           <table style={{ tableLayout: 'fixed', display: 'block', width: '100%' }}>
           <tr>
-            <td style={{ width: '55%', paddingLeft: '65px' }}>
-              <table style={{ width: '100%', tableLayout: 'fixed' }}>
-                <tr>
-                  <td style={{ width: '50%', verticalAlign: 'top' }}>
-                    {(currentState === 'US') &&
-                      <label className="subLabel">Make a selection to change the line graph&nbsp;&nbsp;</label>
-                    }
-                  </td>
-                  <td style={{ width: '18%', verticalAlign: 'top' }}>
-                    <div>
-                      {(currentState === 'US') &&
-                        <label title="Check to select all drugs.">
-                          <input id="toggleSelectAll" type="checkbox" checked={selectAllFlag}
-                            onChange={(e) => {
-                              if (e.target.checked) {
-                                setCurrentDrug(currentDrug);
-                                selectAllDrugs();
-                                setDeselectAllFlag(false);
-                                setSelectAllFlag(true);
-                              }
-                              else {
-                                setCurrentDrug(currentDrug);
-                                setselectedDrugs([currentDrug])
-                                setSelectAllFlag(false);
-                              }
-                            }} /> Select All
-                        </label>
-
+            <td style={{ width: '55%', paddingLeft: '15px' }}>
+                <table style={{ width: '100%', tableLayout: 'fixed' }}>
+                  <tr>
+                    <td style={{ width: '50%', verticalAlign: 'top', textAlign: showCompare ? 'right' : 'left' }}>
+                       {!showOverall && !showCompare && <label className="subLabel">Make a selection to change the line graph&nbsp;&nbsp;</label>}
+                       {showCompare && <label className="subLabel">Select a jurisdiction to compare:&nbsp;&nbsp;</label>}
+                    </td>
+                    <td style={{ width: '18%', verticalAlign: 'top' }}>
+                      {!showOverall && !showCompare && 
+                      <div>
+                          <label title="Check to select all drugs.">
+                            <input id="toggleSelectAll" type="checkbox" checked={selectAllFlag}
+                              onChange={(e) => {
+                                if (e.target.checked) {
+                                  setCurrentDrug(currentDrug);
+                                  selectAllDrugs();
+                                  setDeselectAllFlag(false);
+                                  setSelectAllFlag(true);
+                                }
+                                else {
+                                  setCurrentDrug(currentDrug);
+                                  setselectedDrugs([currentDrug])
+                                  setSelectAllFlag(false);
+                                }
+                              }} /> Select All
+                          </label>
+                      </div>
                       }
-                    </div>
-                  </td>
-                  <td style={{ width: '20%', verticalAlign: 'top' }}>
-                    <div>
-                      {(currentState === 'US') &&
-                        <label title="Check to clear all drugs, except current drug.">
-                          <input id="toggleClearAll" type="checkbox" checked={deselectAllFlag}
-                            onChange={(e) => {
-                              if (e.target.checked) {
-                                setCurrentDrug(currentDrug);
-                                setselectedDrugs([currentDrug])
-                                setDeselectAllFlag(true);
-                                setSelectAllFlag(false);
-                              }
-                              else {
-                                setCurrentDrug(currentDrug);
-                                setselectedDrugs([currentDrug]);
-                                setDeselectAllFlag(false);
-                              }
-                            }} /> Clear All
-                        </label>
+                      {showCompare && 
+                      <div>
+                          <Select params={{
+                            key: 'jurisdiction',
+                            label: '',
+                            noSelectPrefix: true,
+                            value: compareState,
+                            onChange: (param) => {
+                              setCompareState(param);
+                              setOnlyCurrentDrug(true);
+                            },
+                            options: stateDropdownOptionsCompare,
+                            optionLabel: (key) => key != 'US' ? stateNames[key] : stateNames[key] + ' (' + (Object.keys(stateDropdownOptions).length - 1) + ' Jurisdictions)'
+                          }} />
+                      </div>
                       }
-                    </div>
-                  </td>
-                </tr>
-              </table>
+                    </td>
+                    <td style={{ width: '20%', verticalAlign: 'top' }}>
+                      {!showOverall && !showCompare &&
+                      <div>
+                          <label title="Check to clear all drugs, except current drug.">
+                            <input id="toggleClearAll" type="checkbox" checked={deselectAllFlag}
+                              onChange={(e) => {
+                                if (e.target.checked) {
+                                  setCurrentDrug(currentDrug);
+                                  setselectedDrugs([currentDrug])
+                                  setDeselectAllFlag(true);
+                                  setSelectAllFlag(false);
+                                }
+                                else {
+                                  setCurrentDrug(currentDrug);
+                                  setselectedDrugs([currentDrug]);
+                                  setDeselectAllFlag(false);
+                                }
+                              }} /> Clear All
+                          </label>
+                      </div>
+                      }       
+                    </td>
+                  </tr>
+                </table>
             </td>
-            <td style={{ width: '15%' }}></td>
-            <td style={{ width: '30%' }}>
+            <td style={{ width: '5%' }}></td>
+            <td style={{ width: '50%' }}>
               <table>
                 <tr>
                   <td style={{ width: '76%', textAlign: 'right' }}>
+                    {(currentState !== 'US') &&
+                      <div style={{ float: 'right' }}>
+                        <label class="toggleC" title={'Toggle to compare with a jurisdiction.'}>
+                          <input id="toggleCompare" class="toggleC-input" type="checkbox" checked={showCompare} disabled={showOverall}
+                            onChange={(e) => {
+                              if (e.target.checked) {
+                                setCompareToggle(true)
+                                setCompareState(stateDropdownOptionsCompare[0]);
+                              }
+                              else {
+                                setCompareToggle(false)
+                                setCompareState('');
+                              }
+                            }} />
+                          <span class="toggleC-label" data-off="Compare Off"
+                            data-on="Compare On">
+                          </span>
+                          <span class="toggleC-handle"></span>
+                        </label>
+                      </div>
+                    }
+                  </td>
+                  <td style={{ width: '28%', textAlign: 'right' }}>
+                    {(currentState !== 'US') &&
+                      <div style={{ float: 'right' }}>
+                        <label class="toggleB" title={'Toggle to compare with overall.'}>
+                          <input id="toggleOverall" class="toggleB-input" type="checkbox" checked={showOverall} disabled={showCompare}
+                            onChange={(e) => {
+                              if (e.target.checked) {
+                                setOverallToggle(true)
+                              }
+                              else {
+                                setOverallToggle(false)
+                              }
+                            }} />
+                          <span class="toggleB-label" data-off="Overall Off"
+                            data-on="Overall On">
+                          </span>
+                          <span class="toggleB-handle"></span>
+                        </label>
+                      </div>
+                    }
+                  </td>
+                  <td style={{ width: '28%', textAlign: 'right' }}>
                     {(currentTimeframe === 'Annual') &&
                       <div style={{ float: 'right' }}>
                         <label class="toggleA" title={'Toggle to hover over a data point on the line chart to view percent change for the selected year compared to the previous year.'}>
@@ -682,10 +746,8 @@ export default function App(params) {
 
           </tr>
           <tr>
-            <td colSpan='2' class="drugsDivTop" style={{ textAlign: 'left', verticalAlign: 'top', paddingLeft: '65px' }}>
-              {(currentState === 'US') &&
-                getDrugControls()
-              }
+            <td colSpan='2' class="drugsDivTop" style={{ textAlign: 'left', verticalAlign: 'top', paddingLeft: '15px' }}>
+                {!showOverall && !showCompare && getDrugControls()}
             </td>
             {(!accessible && currentTimeframe === 'Annual') &&
               <td>
@@ -693,20 +755,18 @@ export default function App(params) {
               </td>
             }
           </tr>
+
           </table>
         }
         {isSmallViewport && 
           <table style={{ tableLayout: 'fixed', display: 'block', width: '100%' }}>
           <tr>
             <td colSpan='2'>
-                {(currentState === 'US') &&
                       <label className="subLabel">Make a selection to change the line graph&nbsp;&nbsp;</label>
-                    }
             </td>
           </tr>
           <tr>
                   <td style={{ width: '50%!important', verticalAlign: 'top', textAlign: 'left' }}>
-                      {(currentState === 'US') &&
                         <label title="Check to select all drugs.">
                           <input id="toggleSelectAll" type="checkbox" checked={selectAllFlag}
                             onChange={(e) => {
@@ -723,11 +783,9 @@ export default function App(params) {
                               }
                             }} /> Select All
                         </label>
-                      }
                   </td>
                   <td style={{ width: '50%', verticalAlign: 'top', textAlign: 'left' }}>
                     <div>
-                      {(currentState === 'US') &&
                         <label title="Check to clear all drugs, except current drug.">
                           <input id="toggleClearAll" type="checkbox" checked={deselectAllFlag}
                             onChange={(e) => {
@@ -744,7 +802,6 @@ export default function App(params) {
                               }
                             }} /> Clear All
                         </label>
-                      }
                     </div>
                   </td>
           </tr>
@@ -820,9 +877,7 @@ export default function App(params) {
           <br></br>
           <tr>
             <td colSpan='2' class="drugsDivTop" style={{ textAlign: 'left', verticalAlign: 'top', paddingLeft: '5px' }}>
-              {(currentState === 'US') &&
-                getDrugControls()
-              }
+                {getDrugControls()}
             </td>
           </tr>
           <tr>
@@ -998,7 +1053,6 @@ export default function App(params) {
             supportedStates[st] = stateNames[st];
         }
         setStateDropdownOptions(Object.keys(supportedStates))
-
       });
 
     await fetch(dataPath + 'Overall_By_Sex_Age.json')
@@ -1335,7 +1389,7 @@ export default function App(params) {
           <td>
             <div class="containerLC">
               <div class={currentState === 'US' ? "chartDivAll" : "chartDivAll"}>
-                <LineChart params={{ data, monthNames, stateNames, drugOptions, currentTimeframe, currentDataSource, currentDrug, currentState, currentYear, currentMonth, width, stateDropdownOptions, lookupPeriodStartYear, lookupPeriodStartMonth, lookupPeriodEndYear, lookupPeriodEndMonth, showLabels, showPercent, showCount, isPeriod, currentDrugOnly, supportedYears, selectedDrugs, accessible }} />
+                <LineChart params={{ data, monthNames, stateNames, drugOptions, currentTimeframe, currentDataSource, currentDrug, currentState, currentYear, currentMonth, width, stateDropdownOptions, lookupPeriodStartYear, lookupPeriodStartMonth, lookupPeriodEndYear, lookupPeriodEndMonth, showLabels, showPercent, showCount, showOverall, showCompare, compareState, isPeriod, currentDrugOnly, supportedYears, selectedDrugs, accessible }} />
               </div>
             </div>
           </td>
@@ -1347,7 +1401,7 @@ export default function App(params) {
 
       </table>
     </>,
-    [data, monthNames, stateNames, drugOptions, currentTimeframe, currentDataSource, currentDrug, currentState, currentYear, currentMonth, width, stateDropdownOptions, lookupPeriodStartYear, lookupPeriodStartMonth, lookupPeriodEndYear, lookupPeriodEndMonth, showLabels, showPercent, showCount, isPeriod, currentDrugOnly, supportedYears, selectedDrugs]);
+    [data, monthNames, stateNames, drugOptions, currentTimeframe, currentDataSource, currentDrug, currentState, currentYear, currentMonth, width, stateDropdownOptions, lookupPeriodStartYear, lookupPeriodStartMonth, lookupPeriodEndYear, lookupPeriodEndMonth, showLabels, showPercent, showCount, showOverall, showCompare, compareState, isPeriod, currentDrugOnly, supportedYears, selectedDrugs]);
 
   const sexAgeChartsMemo = useMemo(() =>
     <>
@@ -1375,6 +1429,7 @@ export default function App(params) {
 
   const usaMapMemo = useMemo(() =>
     (currentDataSource === 'ED' && currentDrug === 'alldrug') ? <>
+      <h2 className="data-bite-header sub" style={{ backgroundColor: drugColor }}>{getSubBannerText('usaMap')}<sup>3,4</sup>?</h2>
       {!accessible && <div><small><i>The county-level heat map is only available for the rate (annual and 5-year) of ED visits for nonfatal all drug overdoses due to substantial suppression that would result if other comparisons were made. The county heat map uses patient county of residence data. By hovering, the heat map shows ED visits within each state: county-level numbers reflect in-state residents, while state-level numbers include both in-state residents and out-of-state residents (individuals residing in other states but visiting in-state facilities).</i></small></div>}
       {accessible && <div><small><i>The county-level tables are only available for the rate (annual and 5-year) of ED visits for nonfatal all drug overdoses due to substantial suppression that would result if other comparisons were made. This table uses patient county of residence data. County-level numbers reflect in-state residents who visited in-state facilities.</i></small></div>}
       <br></br>
@@ -1528,6 +1583,8 @@ export default function App(params) {
                       setOnlyCurrentDrug(true);
                     else
                       setOnlyCurrentDrug(false);
+
+                    setStateDropdownOptionsCompare(getSupportedStatesForCompare(stateDropdownOptions, param))
                   },
 
 
@@ -1685,6 +1742,8 @@ export default function App(params) {
                             setOnlyCurrentDrug(true);
                           else
                             setOnlyCurrentDrug(false);
+
+                          setStateDropdownOptionsCompare(getSupportedStatesForCompare(stateDropdownOptions))
                         },
 
 
@@ -1779,7 +1838,7 @@ export default function App(params) {
               {accessible && getFootNotesForData('Line', true)}
             </section>
 
-            {accessible &&
+          {accessible &&
               <section>
                 <div className="datatable-container-header">
                   <button className="h2 h2-toggle button-toggle" style={{ backgroundColor: drugOptions[selectedDrugsState[0]].color }} onClick={toggleStateTable}>
@@ -1816,8 +1875,8 @@ export default function App(params) {
             </section>
             }
             {!accessible &&
-              <section>
-                <h2 className="data-bite-header sub" style={{ backgroundColor: drugOptions[selectedDrugsState[0]].color }}>{getSubBannerText('statebarChart')}<sup>3,4</sup>?</h2>
+            <section>
+              <h2 className="data-bite-header sub" style={{ backgroundColor: drugOptions[selectedDrugsState[0]].color }}>{getSubBannerText('statebarChart')}<sup>3,4</sup>?</h2>
               <table>
                 <tr>
                       {!isSmallViewport && <td style={{'width': '8%'}}></td>}
@@ -1839,9 +1898,8 @@ export default function App(params) {
               </table>
               {stateBarChartMemo}
               {getFootNotesForData('State', false)}
-              </section>
+            </section>
             }
-
             <section>
               <h2 className="data-bite-header sub" style={{ backgroundColor: drugOptions[selectedDrugsSexAge[0]].color }}>{getSubBannerText('sexChart')}<sup>3,4</sup>?</h2>
               <table>
@@ -1894,7 +1952,6 @@ export default function App(params) {
                 {(accessible && (currentDataSource == 'ED' && currentDrug == 'alldrug')) && getFootNotesForData('Map', false)}
               </section>
             }
-
           </>
         )}
       </div>

--- a/src/App.js
+++ b/src/App.js
@@ -878,7 +878,7 @@ export default function App(params) {
           <br></br>
           <tr>
             <td colSpan='2' class="drugsDivTop" style={{ textAlign: 'left', verticalAlign: 'top', paddingLeft: '5px' }}>
-                {getDrugControls()}
+                {!showOverall && !showCompare && getDrugControls()}
             </td>
           </tr>
           <tr>

--- a/src/App.js
+++ b/src/App.js
@@ -209,6 +209,7 @@ export default function App(params) {
   const [timeframeChanged, setTimeframeChanged] = useState(false);
   const [activeTab, setActiveTab] = useState(0);
   const { accessible } = params;
+
   const [width, setWidth] = useState(accessible ? 0 : 100);
   
   const dataPath = window.location.origin.includes('localhost') ? '/data/' : '/overdose-prevention/data-dashboards/dose-discharge-dashboard/data/';
@@ -1429,7 +1430,6 @@ export default function App(params) {
 
   const usaMapMemo = useMemo(() =>
     (currentDataSource === 'ED' && currentDrug === 'alldrug') ? <>
-      <h2 className="data-bite-header sub" style={{ backgroundColor: drugColor }}>{getSubBannerText('usaMap')}<sup>3,4</sup>?</h2>
       {!accessible && <div><small><i>The county-level heat map is only available for the rate (annual and 5-year) of ED visits for nonfatal all drug overdoses due to substantial suppression that would result if other comparisons were made. The county heat map uses patient county of residence data. By hovering, the heat map shows ED visits within each state: county-level numbers reflect in-state residents, while state-level numbers include both in-state residents and out-of-state residents (individuals residing in other states but visiting in-state facilities).</i></small></div>}
       {accessible && <div><small><i>The county-level tables are only available for the rate (annual and 5-year) of ED visits for nonfatal all drug overdoses due to substantial suppression that would result if other comparisons were made. This table uses patient county of residence data. County-level numbers reflect in-state residents who visited in-state facilities.</i></small></div>}
       <br></br>

--- a/src/accessibility.js
+++ b/src/accessibility.js
@@ -140,7 +140,7 @@ export const AccessibilityFunctions = {
         return isNaN(cnt) ? cnt : Number(cnt).toLocaleString('en-US');
     },
 
-    generateLineChartData : (stateData, data, currentDataSource, countsDataYearly, countsDataMonthly, currentDrug, selDrugs, state, stateNames, currentTimeframe, showPercent, showCount, changePrecValues) => {
+    generateLineChartData : (stateData, data, currentDataSource, countsDataYearly, countsDataMonthly, currentDrug, selDrugs, state, stateNames, currentTimeframe, showPercent, showCount, showOverall, changePrecValues) => {
 
       let myData = {};
       if (state == 'US') {
@@ -247,7 +247,8 @@ export const AccessibilityFunctions = {
           let obj = {};
 
           if (currentDrug == 'alldrug') {
-            obj['Overall'] = data['US'][i].alldrug;
+            if (showOverall)
+              obj['Overall'] = data['US'][i].alldrug;
 
             for (var j=0;j<Object.keys(data[state]).length;j++)
             {
@@ -257,7 +258,8 @@ export const AccessibilityFunctions = {
           }
 
           if (currentDrug == 'benzodiazepine') {
-            obj['Overall'] = data['US'][i].benzodiazepine;
+            if (showOverall)
+              obj['Overall'] = data['US'][i].benzodiazepine;
 
             for (var j=0;j<Object.keys(data[state]).length;j++)
             {
@@ -267,7 +269,8 @@ export const AccessibilityFunctions = {
           }
 
           if (currentDrug == 'cocaine') {
-            obj['Overall'] = data['US'][i].cocaine;
+            if (showOverall)
+              obj['Overall'] = data['US'][i].cocaine;
 
             for (var j=0;j<Object.keys(data[state]).length;j++)
             {
@@ -277,7 +280,8 @@ export const AccessibilityFunctions = {
           }
 
           if (currentDrug == 'fentanyl') {
-            obj['Overall'] = data['US'][i].fentanyl;
+            if (showOverall)
+              obj['Overall'] = data['US'][i].fentanyl;
 
             for (var j=0;j<Object.keys(data[state]).length;j++)
             {
@@ -287,7 +291,8 @@ export const AccessibilityFunctions = {
           }
 
           if (currentDrug == 'heroin') {
-            obj['Overall'] = data['US'][i].heroin;
+            if (showOverall)
+              obj['Overall'] = data['US'][i].heroin;
 
             for (var j=0;j<Object.keys(data[state]).length;j++)
             {
@@ -297,7 +302,8 @@ export const AccessibilityFunctions = {
           }
 
           if (currentDrug == 'methamphetamine') {
-            obj['Overall'] = data['US'][i].methamphetamine;
+            if (showOverall)
+              obj['Overall'] = data['US'][i].methamphetamine;
 
             for (var j=0;j<Object.keys(data[state]).length;j++)
             {
@@ -307,7 +313,8 @@ export const AccessibilityFunctions = {
           }
 
           if (currentDrug == 'opioid') {
-            obj['Overall'] = data['US'][i].opioid;
+            if (showOverall)
+              obj['Overall'] = data['US'][i].opioid;
 
             for (var j=0;j<Object.keys(data[state]).length;j++)
             {
@@ -317,7 +324,8 @@ export const AccessibilityFunctions = {
           }
 
           if (currentDrug == 'stimulant') {
-            obj['Overall'] = data['US'][i].stimulant;
+            if (showOverall)
+              obj['Overall'] = data['US'][i].stimulant;
 
             for (var j=0;j<Object.keys(data[state]).length;j++)
             {
@@ -327,13 +335,16 @@ export const AccessibilityFunctions = {
           }
 
           if (showPercent)
-            obj['Overall_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, 'US', changePrecValues);
+            if (showOverall)
+              obj['Overall_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, 'US', changePrecValues);
 
           if (showPercent)
             obj['state_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, state, changePrecValues);
 
           if (showCount) {
+              if (showOverall)
               obj['Overall_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly(currentDrug, data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly(currentDrug, data['US'][i].year, state, countsDataYearly);
+            
               obj['state_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthlyNonUS(currentDrug, data['US'][i].year, state, stateData, currentDataSource) : AccessibilityFunctions.getCountYearlyNonUS(currentDrug, data['US'][i].year, state, stateData, currentDataSource);
           }
 

--- a/src/accessibility.js
+++ b/src/accessibility.js
@@ -253,96 +253,145 @@ export const AccessibilityFunctions = {
               if (showCompare)
                 obj['Overall'] = data[compareState][i].alldrug;
 
+              if (showPercent)
+                if (showCompare)
+                  obj['Overall_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, compareState, changePrecValues);
+                
               for (var j=0;j<Object.keys(data[state]).length;j++)
               {
                 if (data['US'][i].year == data[state][j].year) 
                   obj['state'] = data[state][j].alldrug;
               }
+
+              if (showPercent)
+                obj['state_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, state, changePrecValues);
             }
 
             if (currentDrug == 'benzodiazepine') {
               if (showCompare)
                 obj['Overall'] = data[compareState][i].benzodiazepine;
 
+              if (showPercent)
+                if (showCompare)
+                  obj['Overall_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, compareState, changePrecValues);
+                
               for (var j=0;j<Object.keys(data[state]).length;j++)
               {
                 if (data['US'][i].year == data[state][j].year) 
                   obj['state'] = data[state][j].benzodiazepine;
               }
+
+              if (showPercent)
+                obj['state_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, state, changePrecValues);
             }
 
             if (currentDrug == 'cocaine') {
               if (showCompare)
                 obj['Overall'] = data[compareState][i].cocaine;
 
+              if (showPercent)
+                if (showCompare)
+                  obj['Overall_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, compareState, changePrecValues);
+                
               for (var j=0;j<Object.keys(data[state]).length;j++)
               {
                 if (data['US'][i].year == data[state][j].year) 
                   obj['state'] = data[state][j].cocaine;
               }
+
+              if (showPercent)
+                obj['state_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, state, changePrecValues);
             }
 
             if (currentDrug == 'fentanyl') {
               if (showCompare)
                 obj['Overall'] = data[compareState][i].fentanyl;
 
+              if (showPercent)
+                if (showCompare)
+                  obj['Overall_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, compareState, changePrecValues);
+                
               for (var j=0;j<Object.keys(data[state]).length;j++)
               {
                 if (data['US'][i].year == data[state][j].year) 
                   obj['state'] = data[state][j].fentanyl;
               }
+
+              if (showPercent)
+                obj['state_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, state, changePrecValues);
             }
 
             if (currentDrug == 'heroin') {
               if (showCompare)
                 obj['Overall'] = data[compareState][i].heroin;
 
+              if (showPercent)
+                if (showCompare)
+                  obj['Overall_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, compareState, changePrecValues);
+                
               for (var j=0;j<Object.keys(data[state]).length;j++)
               {
                 if (data['US'][i].year == data[state][j].year) 
                   obj['state'] = data[state][j].heroin;
               }
+
+              if (showPercent)
+                obj['state_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, state, changePrecValues);
             }
 
             if (currentDrug == 'methamphetamine') {
               if (showCompare)
                 obj['Overall'] = data[compareState][i].methamphetamine;
 
+              if (showPercent)
+                if (showCompare)
+                  obj['Overall_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, compareState, changePrecValues);
+                
               for (var j=0;j<Object.keys(data[state]).length;j++)
               {
                 if (data['US'][i].year == data[state][j].year) 
                   obj['state'] = data[state][j].methamphetamine;
               }
+
+              if (showPercent)
+                obj['state_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, state, changePrecValues);
             }
 
             if (currentDrug == 'opioid') {
               if (showCompare)
                 obj['Overall'] = data[compareState][i].opioid;
 
+              if (showPercent)
+                if (showCompare)
+                  obj['Overall_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, compareState, changePrecValues);
+
               for (var j=0;j<Object.keys(data[state]).length;j++)
               {
                 if (data['US'][i].year == data[state][j].year) 
                   obj['state'] = data[state][j].opioid;
               }
+
+              if (showPercent)
+                obj['state_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, state, changePrecValues);
             }
 
             if (currentDrug == 'stimulant') {
               if (showCompare)
                 obj['Overall'] = data[compareState][i].stimulant;
 
+              if (showPercent)
+                if (showCompare)
+                  obj['Overall_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, compareState, changePrecValues);
+
               for (var j=0;j<Object.keys(data[state]).length;j++)
               {
                 if (data['US'][i].year == data[state][j].year) 
                   obj['state'] = data[state][j].stimulant;
               }
+
+              if (showPercent)
+                obj['state_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, state, changePrecValues);
             }
-
-            if (showPercent)
-              if (showCompare)
-                obj['Overall_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, compareState, changePrecValues);
-
-            if (showPercent)
-              obj['state_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, state, changePrecValues);
 
             if (showCount) {
                 if (showCompare)
@@ -366,96 +415,137 @@ export const AccessibilityFunctions = {
               if (showOverall)
                 obj['Overall'] = data['US'][i].alldrug;
 
+              if (showPercent)
+                obj['Overall_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, 'US', changePrecValues);
+              
               for (var j=0;j<Object.keys(data[state]).length;j++)
               {
                 if (data['US'][i].year == data[state][j].year) 
                   obj['state'] = data[state][j].alldrug;
               }
+
+              if (showPercent)
+                obj['state_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, state, changePrecValues);
             }
 
             if (currentDrug == 'benzodiazepine') {
               if (showOverall)
                 obj['Overall'] = data['US'][i].benzodiazepine;
 
+              if (showPercent)
+                obj['Overall_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, 'US', changePrecValues);
+              
               for (var j=0;j<Object.keys(data[state]).length;j++)
               {
                 if (data['US'][i].year == data[state][j].year) 
                   obj['state'] = data[state][j].benzodiazepine;
               }
+
+              if (showPercent)
+                obj['state_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, state, changePrecValues);
             }
 
             if (currentDrug == 'cocaine') {
               if (showOverall)
                 obj['Overall'] = data['US'][i].cocaine;
 
+              if (showPercent)
+                obj['Overall_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, 'US', changePrecValues);
+              
               for (var j=0;j<Object.keys(data[state]).length;j++)
               {
                 if (data['US'][i].year == data[state][j].year) 
                   obj['state'] = data[state][j].cocaine;
               }
+
+              if (showPercent)
+                obj['state_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, state, changePrecValues);
             }
 
             if (currentDrug == 'fentanyl') {
               if (showOverall)
                 obj['Overall'] = data['US'][i].fentanyl;
 
+              if (showPercent)
+                obj['Overall_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, 'US', changePrecValues);
+              
               for (var j=0;j<Object.keys(data[state]).length;j++)
               {
                 if (data['US'][i].year == data[state][j].year) 
                   obj['state'] = data[state][j].fentanyl;
               }
+
+              if (showPercent)
+                obj['state_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, state, changePrecValues);
             }
 
             if (currentDrug == 'heroin') {
               if (showOverall)
                 obj['Overall'] = data['US'][i].heroin;
 
+              if (showPercent)
+                obj['Overall_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, 'US', changePrecValues);
+              
               for (var j=0;j<Object.keys(data[state]).length;j++)
               {
                 if (data['US'][i].year == data[state][j].year) 
                   obj['state'] = data[state][j].heroin;
               }
+
+              if (showPercent)
+                obj['state_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, state, changePrecValues);
             }
 
             if (currentDrug == 'methamphetamine') {
               if (showOverall)
                 obj['Overall'] = data['US'][i].methamphetamine;
 
-              for (var j=0;j<Object.keys(data[state]).length;j++)
+            if (showPercent)
+                obj['Overall_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, 'US', changePrecValues);
+              
+            for (var j=0;j<Object.keys(data[state]).length;j++)
               {
                 if (data['US'][i].year == data[state][j].year) 
                   obj['state'] = data[state][j].methamphetamine;
               }
+
+              if (showPercent)
+                obj['state_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, state, changePrecValues);
             }
 
             if (currentDrug == 'opioid') {
               if (showOverall)
                 obj['Overall'] = data['US'][i].opioid;
 
+            if (showPercent)
+                obj['Overall_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, 'US', changePrecValues);
+              
               for (var j=0;j<Object.keys(data[state]).length;j++)
               {
                 if (data['US'][i].year == data[state][j].year) 
                   obj['state'] = data[state][j].opioid;
               }
+
+              if (showPercent)
+                obj['state_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, state, changePrecValues);
             }
 
             if (currentDrug == 'stimulant') {
               if (showOverall)
                 obj['Overall'] = data['US'][i].stimulant;
 
+            if (showPercent)
+                obj['Overall_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, 'US', changePrecValues);
+
               for (var j=0;j<Object.keys(data[state]).length;j++)
               {
                 if (data['US'][i].year == data[state][j].year) 
                   obj['state'] = data[state][j].stimulant;
               }
+
+              if (showPercent)
+                obj['state_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, state, changePrecValues);
             }
-
-            if (showPercent)
-              if (showOverall)
-                obj['Overall_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, 'US', changePrecValues);
-
-            if (showPercent)
-              obj['state_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, state, changePrecValues);
 
             if (showCount) {
                 if (showOverall)

--- a/src/accessibility.js
+++ b/src/accessibility.js
@@ -140,220 +140,336 @@ export const AccessibilityFunctions = {
         return isNaN(cnt) ? cnt : Number(cnt).toLocaleString('en-US');
     },
 
-    generateLineChartData : (stateData, data, currentDataSource, countsDataYearly, countsDataMonthly, currentDrug, selDrugs, state, stateNames, currentTimeframe, showPercent, showCount, showOverall, changePrecValues) => {
+    generateLineChartData : (stateData, data, currentDataSource, countsDataYearly, countsDataMonthly, currentDrug, selDrugs, state, stateNames, currentTimeframe, showCompare, showOverall, showPercent, showCount, compareState, changePrecValues) => {
 
       let myData = {};
-      if (state == 'US') {
-        for (var i=0;i<Object.keys(data['US']).length;i++)
+      if (!showOverall) {
+        if (!showCompare)
+        { 
+          for (var i=0;i<Object.keys(data['US']).length;i++)
+          {
+            let obj = {};
+
+            if (selDrugs.includes('alldrug')) {
+              obj['alldrug'] = data[state][i].alldrug;
+
+              if (showPercent)
+                obj['alldrug_pct'] = AccessibilityFunctions.getPercChange('alldrug', data['US'][i].year, state, changePrecValues);
+
+            }
+
+            if (selDrugs.includes('benzodiazepine')) {
+              obj['benzodiazepine'] = data[state][i].benzodiazepine;
+
+              if (showPercent)
+                obj['benzodiazepine_pct'] = AccessibilityFunctions.getPercChange('benzodiazepine', data['US'][i].year, state, changePrecValues);
+
+            }
+
+            if (selDrugs.includes('cocaine')) {
+              obj['cocaine'] = data[state][i].cocaine;
+
+              if (showPercent)
+                obj['cocaine_pct'] = AccessibilityFunctions.getPercChange('cocaine', data['US'][i].year, state, changePrecValues);
+
+            }
+
+            if (selDrugs.includes('fentanyl')) {
+              obj['fentanyl'] = data[state][i].fentanyl;
+
+              if (showPercent)
+                obj['fentanyl_pct'] = AccessibilityFunctions.getPercChange('fentanyl', data['US'][i].year, state, changePrecValues);
+            }
+
+            if (selDrugs.includes('heroin')) {
+              obj['heroin'] = data[state][i].heroin;
+
+              if (showPercent)
+                obj['heroin_pct'] = AccessibilityFunctions.getPercChange('heroin', data['US'][i].year, state, changePrecValues);
+
+            }
+
+            if (selDrugs.includes('methamphetamine')) {
+              obj['methamphetamine'] = data[state][i].methamphetamine;
+
+              if (showPercent)
+                obj['methamphetamine_pct'] = AccessibilityFunctions.getPercChange('methamphetamine', data['US'][i].year, state, changePrecValues);
+
+            }
+
+            if (selDrugs.includes('opioid')) {
+              obj['opioid'] = data[state][i].opioid;
+
+              if (showPercent)
+                obj['opioid_pct'] = AccessibilityFunctions.getPercChange('opioid', data['US'][i].year, state, changePrecValues);
+
+            }
+
+            if (selDrugs.includes('stimulant')) {
+              obj['stimulant'] = data[state][i].stimulant;
+
+              if (showPercent)
+                obj['stimulant_pct'] = AccessibilityFunctions.getPercChange('stimulant', data['US'][i].year, state, changePrecValues);
+
+            }
+
+            if (showCount && selDrugs.includes('alldrug'))
+                obj['alldrug_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('alldrug', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('alldrug', data['US'][i].year, state, countsDataYearly);
+            
+              if (showCount && selDrugs.includes('benzodiazepine'))
+                obj['benzodiazepine_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('benzodiazepine', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('benzodiazepine', data['US'][i].year, state, countsDataYearly);
+            
+              if (showCount && selDrugs.includes('cocaine'))
+                obj['cocaine_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('cocaine', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('cocaine', data['US'][i].year, state, countsDataYearly);
+            
+              if (showCount && selDrugs.includes('fentanyl'))
+                obj['fentanyl_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('fentanyl', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('fentanyl', data['US'][i].year, state, countsDataYearly);
+            
+              if (showCount && selDrugs.includes('heroin'))
+                obj['heroin_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('heroin', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('heroin', data['US'][i].year, state, countsDataYearly);
+            
+              if (showCount && selDrugs.includes('methamphetamine'))
+                obj['methamphetamine_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('methamphetamine', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('methamphetamine', data['US'][i].year, state, countsDataYearly);
+            
+              if (showCount && selDrugs.includes('opioid'))
+                obj['opioid_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('opioid', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('opioid', data['US'][i].year, state, countsDataYearly);
+            
+              if (showCount && selDrugs.includes('stimulant'))
+                obj['stimulant_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('stimulant', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('stimulant', data['US'][i].year, state, countsDataYearly);
+
+              let monyr = currentTimeframe == 'Monthly' ? (UtilityFunctions.getMonthName(String(Number(data['US'][i].year.substring(4)))) + ' ' + data['US'][i].year.substring(0,4)) : data['US'][i].year;
+
+              myData[monyr] = obj;
+          }
+        }
+        else
         {
-          let obj = {};
 
-          if (selDrugs.includes('alldrug')) {
-            obj['alldrug'] = data['US'][i].alldrug;
+          for (var i=0;i<Object.keys(data[compareState]).length;i++)
+          {
+            let obj = {};
+
+            if (currentDrug == 'alldrug') {
+              if (showCompare)
+                obj['Overall'] = data[compareState][i].alldrug;
+
+              for (var j=0;j<Object.keys(data[state]).length;j++)
+              {
+                if (data['US'][i].year == data[state][j].year) 
+                  obj['state'] = data[state][j].alldrug;
+              }
+            }
+
+            if (currentDrug == 'benzodiazepine') {
+              if (showCompare)
+                obj['Overall'] = data[compareState][i].benzodiazepine;
+
+              for (var j=0;j<Object.keys(data[state]).length;j++)
+              {
+                if (data['US'][i].year == data[state][j].year) 
+                  obj['state'] = data[state][j].benzodiazepine;
+              }
+            }
+
+            if (currentDrug == 'cocaine') {
+              if (showCompare)
+                obj['Overall'] = data[compareState][i].cocaine;
+
+              for (var j=0;j<Object.keys(data[state]).length;j++)
+              {
+                if (data['US'][i].year == data[state][j].year) 
+                  obj['state'] = data[state][j].cocaine;
+              }
+            }
+
+            if (currentDrug == 'fentanyl') {
+              if (showCompare)
+                obj['Overall'] = data[compareState][i].fentanyl;
+
+              for (var j=0;j<Object.keys(data[state]).length;j++)
+              {
+                if (data['US'][i].year == data[state][j].year) 
+                  obj['state'] = data[state][j].fentanyl;
+              }
+            }
+
+            if (currentDrug == 'heroin') {
+              if (showCompare)
+                obj['Overall'] = data[compareState][i].heroin;
+
+              for (var j=0;j<Object.keys(data[state]).length;j++)
+              {
+                if (data['US'][i].year == data[state][j].year) 
+                  obj['state'] = data[state][j].heroin;
+              }
+            }
+
+            if (currentDrug == 'methamphetamine') {
+              if (showCompare)
+                obj['Overall'] = data[compareState][i].methamphetamine;
+
+              for (var j=0;j<Object.keys(data[state]).length;j++)
+              {
+                if (data['US'][i].year == data[state][j].year) 
+                  obj['state'] = data[state][j].methamphetamine;
+              }
+            }
+
+            if (currentDrug == 'opioid') {
+              if (showCompare)
+                obj['Overall'] = data[compareState][i].opioid;
+
+              for (var j=0;j<Object.keys(data[state]).length;j++)
+              {
+                if (data['US'][i].year == data[state][j].year) 
+                  obj['state'] = data[state][j].opioid;
+              }
+            }
+
+            if (currentDrug == 'stimulant') {
+              if (showCompare)
+                obj['Overall'] = data[compareState][i].stimulant;
+
+              for (var j=0;j<Object.keys(data[state]).length;j++)
+              {
+                if (data['US'][i].year == data[state][j].year) 
+                  obj['state'] = data[state][j].stimulant;
+              }
+            }
 
             if (showPercent)
-              obj['alldrug_pct'] = AccessibilityFunctions.getPercChange('alldrug', data['US'][i].year, state, changePrecValues);
-
-          }
-
-          if (selDrugs.includes('benzodiazepine')) {
-            obj['benzodiazepine'] = data['US'][i].benzodiazepine;
+              if (showCompare)
+                obj['Overall_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, compareState, changePrecValues);
 
             if (showPercent)
-              obj['benzodiazepine_pct'] = AccessibilityFunctions.getPercChange('benzodiazepine', data['US'][i].year, state, changePrecValues);
+              obj['state_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, state, changePrecValues);
 
-          }
-
-          if (selDrugs.includes('cocaine')) {
-            obj['cocaine'] = data['US'][i].cocaine;
-
-            if (showPercent)
-              obj['cocaine_pct'] = AccessibilityFunctions.getPercChange('cocaine', data['US'][i].year, state, changePrecValues);
-
-          }
-
-          if (selDrugs.includes('fentanyl')) {
-            obj['fentanyl'] = data['US'][i].fentanyl;
-
-            if (showPercent)
-              obj['fentanyl_pct'] = AccessibilityFunctions.getPercChange('fentanyl', data['US'][i].year, state, changePrecValues);
-          }
-
-          if (selDrugs.includes('heroin')) {
-            obj['heroin'] = data['US'][i].heroin;
-
-            if (showPercent)
-              obj['heroin_pct'] = AccessibilityFunctions.getPercChange('heroin', data['US'][i].year, state, changePrecValues);
-
-          }
-
-          if (selDrugs.includes('methamphetamine')) {
-            obj['methamphetamine'] = data['US'][i].methamphetamine;
-
-            if (showPercent)
-              obj['methamphetamine_pct'] = AccessibilityFunctions.getPercChange('methamphetamine', data['US'][i].year, state, changePrecValues);
-
-          }
-
-          if (selDrugs.includes('opioid')) {
-            obj['opioid'] = data['US'][i].opioid;
-
-            if (showPercent)
-              obj['opioid_pct'] = AccessibilityFunctions.getPercChange('opioid', data['US'][i].year, state, changePrecValues);
-
-          }
-
-          if (selDrugs.includes('stimulant')) {
-            obj['stimulant'] = data['US'][i].stimulant;
-
-            if (showPercent)
-              obj['stimulant_pct'] = AccessibilityFunctions.getPercChange('stimulant', data['US'][i].year, state, changePrecValues);
-
-          }
-
-          if (showCount && selDrugs.includes('alldrug'))
-              obj['alldrug_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('alldrug', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('alldrug', data['US'][i].year, state, countsDataYearly);
-          
-            if (showCount && selDrugs.includes('benzodiazepine'))
-              obj['benzodiazepine_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('benzodiazepine', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('benzodiazepine', data['US'][i].year, state, countsDataYearly);
-          
-            if (showCount && selDrugs.includes('cocaine'))
-              obj['cocaine_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('cocaine', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('cocaine', data['US'][i].year, state, countsDataYearly);
-          
-            if (showCount && selDrugs.includes('fentanyl'))
-              obj['fentanyl_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('fentanyl', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('fentanyl', data['US'][i].year, state, countsDataYearly);
-          
-            if (showCount && selDrugs.includes('heroin'))
-              obj['heroin_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('heroin', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('heroin', data['US'][i].year, state, countsDataYearly);
-          
-            if (showCount && selDrugs.includes('methamphetamine'))
-              obj['methamphetamine_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('methamphetamine', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('methamphetamine', data['US'][i].year, state, countsDataYearly);
-          
-            if (showCount && selDrugs.includes('opioid'))
-              obj['opioid_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('opioid', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('opioid', data['US'][i].year, state, countsDataYearly);
-          
-            if (showCount && selDrugs.includes('stimulant'))
-              obj['stimulant_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly('stimulant', data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly('stimulant', data['US'][i].year, state, countsDataYearly);
+            if (showCount) {
+                if (showCompare)
+                obj['Overall_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly(currentDrug, data['US'][i].year, compareState, countsDataMonthly) : AccessibilityFunctions.getCountYearly(currentDrug, data['US'][i].year, compareState, countsDataYearly);
+              
+                obj['state_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthlyNonUS(currentDrug, data['US'][i].year, state, stateData, currentDataSource) : AccessibilityFunctions.getCountYearlyNonUS(currentDrug, data['US'][i].year, state, stateData, currentDataSource);
+            }
 
             let monyr = currentTimeframe == 'Monthly' ? (UtilityFunctions.getMonthName(String(Number(data['US'][i].year.substring(4)))) + ' ' + data['US'][i].year.substring(0,4)) : data['US'][i].year;
-
             myData[monyr] = obj;
+          }
         }
       }
       else
       {
-        for (var i=0;i<Object.keys(data['US']).length;i++)
-        {
-          let obj = {};
+          for (var i=0;i<Object.keys(data['US']).length;i++)
+          {
+            let obj = {};
 
-          if (currentDrug == 'alldrug') {
-            if (showOverall)
-              obj['Overall'] = data['US'][i].alldrug;
-
-            for (var j=0;j<Object.keys(data[state]).length;j++)
-            {
-              if (data['US'][i].year == data[state][j].year) 
-                obj['state'] = data[state][j].alldrug;
-            }
-          }
-
-          if (currentDrug == 'benzodiazepine') {
-            if (showOverall)
-              obj['Overall'] = data['US'][i].benzodiazepine;
-
-            for (var j=0;j<Object.keys(data[state]).length;j++)
-            {
-              if (data['US'][i].year == data[state][j].year) 
-                obj['state'] = data[state][j].benzodiazepine;
-            }
-          }
-
-          if (currentDrug == 'cocaine') {
-            if (showOverall)
-              obj['Overall'] = data['US'][i].cocaine;
-
-            for (var j=0;j<Object.keys(data[state]).length;j++)
-            {
-              if (data['US'][i].year == data[state][j].year) 
-                obj['state'] = data[state][j].cocaine;
-            }
-          }
-
-          if (currentDrug == 'fentanyl') {
-            if (showOverall)
-              obj['Overall'] = data['US'][i].fentanyl;
-
-            for (var j=0;j<Object.keys(data[state]).length;j++)
-            {
-              if (data['US'][i].year == data[state][j].year) 
-                obj['state'] = data[state][j].fentanyl;
-            }
-          }
-
-          if (currentDrug == 'heroin') {
-            if (showOverall)
-              obj['Overall'] = data['US'][i].heroin;
-
-            for (var j=0;j<Object.keys(data[state]).length;j++)
-            {
-              if (data['US'][i].year == data[state][j].year) 
-                obj['state'] = data[state][j].heroin;
-            }
-          }
-
-          if (currentDrug == 'methamphetamine') {
-            if (showOverall)
-              obj['Overall'] = data['US'][i].methamphetamine;
-
-            for (var j=0;j<Object.keys(data[state]).length;j++)
-            {
-              if (data['US'][i].year == data[state][j].year) 
-                obj['state'] = data[state][j].methamphetamine;
-            }
-          }
-
-          if (currentDrug == 'opioid') {
-            if (showOverall)
-              obj['Overall'] = data['US'][i].opioid;
-
-            for (var j=0;j<Object.keys(data[state]).length;j++)
-            {
-              if (data['US'][i].year == data[state][j].year) 
-                obj['state'] = data[state][j].opioid;
-            }
-          }
-
-          if (currentDrug == 'stimulant') {
-            if (showOverall)
-              obj['Overall'] = data['US'][i].stimulant;
-
-            for (var j=0;j<Object.keys(data[state]).length;j++)
-            {
-              if (data['US'][i].year == data[state][j].year) 
-                obj['state'] = data[state][j].stimulant;
-            }
-          }
-
-          if (showPercent)
-            if (showOverall)
-              obj['Overall_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, 'US', changePrecValues);
-
-          if (showPercent)
-            obj['state_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, state, changePrecValues);
-
-          if (showCount) {
+            if (currentDrug == 'alldrug') {
               if (showOverall)
-              obj['Overall_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly(currentDrug, data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly(currentDrug, data['US'][i].year, state, countsDataYearly);
-            
-              obj['state_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthlyNonUS(currentDrug, data['US'][i].year, state, stateData, currentDataSource) : AccessibilityFunctions.getCountYearlyNonUS(currentDrug, data['US'][i].year, state, stateData, currentDataSource);
+                obj['Overall'] = data['US'][i].alldrug;
+
+              for (var j=0;j<Object.keys(data[state]).length;j++)
+              {
+                if (data['US'][i].year == data[state][j].year) 
+                  obj['state'] = data[state][j].alldrug;
+              }
+            }
+
+            if (currentDrug == 'benzodiazepine') {
+              if (showOverall)
+                obj['Overall'] = data['US'][i].benzodiazepine;
+
+              for (var j=0;j<Object.keys(data[state]).length;j++)
+              {
+                if (data['US'][i].year == data[state][j].year) 
+                  obj['state'] = data[state][j].benzodiazepine;
+              }
+            }
+
+            if (currentDrug == 'cocaine') {
+              if (showOverall)
+                obj['Overall'] = data['US'][i].cocaine;
+
+              for (var j=0;j<Object.keys(data[state]).length;j++)
+              {
+                if (data['US'][i].year == data[state][j].year) 
+                  obj['state'] = data[state][j].cocaine;
+              }
+            }
+
+            if (currentDrug == 'fentanyl') {
+              if (showOverall)
+                obj['Overall'] = data['US'][i].fentanyl;
+
+              for (var j=0;j<Object.keys(data[state]).length;j++)
+              {
+                if (data['US'][i].year == data[state][j].year) 
+                  obj['state'] = data[state][j].fentanyl;
+              }
+            }
+
+            if (currentDrug == 'heroin') {
+              if (showOverall)
+                obj['Overall'] = data['US'][i].heroin;
+
+              for (var j=0;j<Object.keys(data[state]).length;j++)
+              {
+                if (data['US'][i].year == data[state][j].year) 
+                  obj['state'] = data[state][j].heroin;
+              }
+            }
+
+            if (currentDrug == 'methamphetamine') {
+              if (showOverall)
+                obj['Overall'] = data['US'][i].methamphetamine;
+
+              for (var j=0;j<Object.keys(data[state]).length;j++)
+              {
+                if (data['US'][i].year == data[state][j].year) 
+                  obj['state'] = data[state][j].methamphetamine;
+              }
+            }
+
+            if (currentDrug == 'opioid') {
+              if (showOverall)
+                obj['Overall'] = data['US'][i].opioid;
+
+              for (var j=0;j<Object.keys(data[state]).length;j++)
+              {
+                if (data['US'][i].year == data[state][j].year) 
+                  obj['state'] = data[state][j].opioid;
+              }
+            }
+
+            if (currentDrug == 'stimulant') {
+              if (showOverall)
+                obj['Overall'] = data['US'][i].stimulant;
+
+              for (var j=0;j<Object.keys(data[state]).length;j++)
+              {
+                if (data['US'][i].year == data[state][j].year) 
+                  obj['state'] = data[state][j].stimulant;
+              }
+            }
+
+            if (showPercent)
+              if (showOverall)
+                obj['Overall_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, 'US', changePrecValues);
+
+            if (showPercent)
+              obj['state_pct'] = AccessibilityFunctions.getPercChange(currentDrug, data['US'][i].year, state, changePrecValues);
+
+            if (showCount) {
+                if (showOverall)
+                obj['Overall_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthly(currentDrug, data['US'][i].year, state, countsDataMonthly) : AccessibilityFunctions.getCountYearly(currentDrug, data['US'][i].year, state, countsDataYearly);
+              
+                obj['state_cnt'] = currentTimeframe == 'Monthly' ? AccessibilityFunctions.getCountMonthlyNonUS(currentDrug, data['US'][i].year, state, stateData, currentDataSource) : AccessibilityFunctions.getCountYearlyNonUS(currentDrug, data['US'][i].year, state, stateData, currentDataSource);
+            }
+
+            let monyr = currentTimeframe == 'Monthly' ? (UtilityFunctions.getMonthName(String(Number(data['US'][i].year.substring(4)))) + ' ' + data['US'][i].year.substring(0,4)) : data['US'][i].year;
+            myData[monyr] = obj;
           }
+    }
 
-          let monyr = currentTimeframe == 'Monthly' ? (UtilityFunctions.getMonthName(String(Number(data['US'][i].year.substring(4)))) + ' ' + data['US'][i].year.substring(0,4)) : data['US'][i].year;
-          myData[monyr] = obj;
-        }
-      }
-
-      return myData;
+    return myData;
   
     },  
 }

--- a/src/components/DataTable508.js
+++ b/src/components/DataTable508.js
@@ -73,14 +73,15 @@ function DataTable508(params) {
     return ret;
   }
 
-  const cleanUp = (val) => {
+  const cleanUp = (val, yr) => {
+
     var ret = val;
 
     if (String(val).indexOf('Data suppressed') >= 0)
       ret = '*';
 
     if (String(val).indexOf('Data not available') >= 0)
-      ret = '†';
+      ret = String(yr).includes('2024') ? '§' : '†';
 
     return ret;
   }
@@ -110,7 +111,7 @@ function DataTable508(params) {
                   <th key={`th-${rowKey}-${rowIndex}`} scope="row">{labelOverrides[rowKey] || rowKey.split('_')[0]}</th>
                   {[data].map((d, i) => 
                     Object.keys(d[keys[0]]).map((colKey, colIndex) => (
-                      <td key={`td-${d[rowKey][colKey]}-${rowIndex}-${colIndex}`}>{cleanUp(d[rowKey][colKey])}</td>
+                      <td key={`td-${d[rowKey][colKey]}-${rowIndex}-${colIndex}`}>{cleanUp(d[rowKey][colKey], rowKey)}</td>
                     ))
                   )}
                 </tr>

--- a/src/components/LineChart.js
+++ b/src/components/LineChart.js
@@ -217,7 +217,7 @@ function LineChart({ params }) {
   const countsDataYearly = getCountsYearly(data.sex, currentDataSource, drugOptions);
   const countsDataMonthly = getCountsMonthly(data.sex, currentDataSource, drugOptions);
   
-  const yScaleDomainPeriod = showCompare ? (UtilityFunctions.calculateYScaleDomainCompare(filteredData, currentDrug, currentState, compareState) * 1.2) : (UtilityFunctions.calculateYScaleDomain(filteredData, currentDrug, selectedDrugs, currentState, showOverall) * 1.2);
+  const yScaleDomainPeriod = (showCompare || showOverall) ? (UtilityFunctions.calculateYScaleDomainCompare(filteredData, currentDrug, currentState, compareState) * 1.2) : (UtilityFunctions.calculateYScaleDomain(filteredData, currentDrug, selectedDrugs, currentState, showOverall) * 1.2);
 
   const currentStaterate = stateNames[currentState];
   const currentStatePctChange = stateNames[currentState] + ' %change in rate';
@@ -657,13 +657,13 @@ function LineChart({ params }) {
       for (var i in selectedDrugs) {
         if (selectedDrugs[i].includes(currentDrug)) {
           let cnt = getCountforDrug(selectedDrugs[i], parmState, val);
-          leftCntStr = leftCntStr + `<span class=${selectedDrugs[i] + 'ToolTip'}` + '>' + (isNaN(cnt) ? (getText(cnt) + (checkIf2024(val) ? '<sup>§</sup>' : '')) : cnt) + '</span></br>'
+          leftCntStr = leftCntStr + `<span class=${selectedDrugs[i] + 'ToolTip'}` + '>' + (isNaN(cnt) ? (getText(cnt) + (checkIf2024(val) ? '<sup>§</sup>' : '')) : Number(cnt).toLocaleString('en-US')) + '</span></br>'
         }
       }
     }
     else {
       let cnt = getCountforDrug(currentDrug, parmState, val);
-      leftCntStr = leftCntStr + `<span class=${currentDrug + 'ToolTip'}` + '>' + (isNaN(cnt) ? (getText(cnt) + (checkIf2024(val) ? '<sup>§</sup>' : '')) : cnt) + '</span></br>'
+      leftCntStr = leftCntStr + `<span class=${currentDrug + 'ToolTip'}` + '>' + (isNaN(cnt) ? (getText(cnt) + (checkIf2024(val) ? '<sup>§</sup>' : '')) : Number(cnt).toLocaleString('en-US')) + '</span></br>'
     }
     return leftCntStr;
   }
@@ -675,6 +675,23 @@ function LineChart({ params }) {
     var leftComStr = `<table><tr><td><p><strong>Overall</strong>` + '</br>' + '(' + numStates + ' Jurisdictions)' + '</p></td></tr>';
     var leftRateStr = `<tr><td><p><strong>Rate</strong>` + '</br>' + getRateHTMLforDrug(inp.selectedDrugs, 'US', val) + '</p></td></tr>';
     var leftCountStr = `<tr><td><p><strong>Count</strong>` + '</br>' + getCountHTMLforDrug(inp.selectedDrugs, 'US', val) + '</p></td></tr></table>';
+    var leftStr = leftComStr + leftRateStr + leftCountStr;
+    var rightComStr = `<table><tr><td><p class='whSpace'><strong>` + inp.stateNames[inp.currentState] + '</strong></br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;' + '</p></td></tr>';
+    var rightRateStr = `<tr><td><p><strong>Rate</strong>` + '</br>' + getRateHTMLforDrug(inp.selectedDrugs, inp.currentState, val) + '</p></td></tr>';
+    var rightCountStr = `<tr><td><p><strong>Count</strong>` + '</br>' + getCountHTMLforDrug(inp.selectedDrugs, inp.currentState, val) + '</p></td></tr></table>';
+    var rightStr = rightComStr + rightRateStr + rightCountStr;
+    var heading = '<div class="tooltipTableLCCenter alignCenter"><h3 style="margin: 0; padding: 0;"><strong>' + (currentTimeframe === 'Annual' ? (val + ' </br>') : ((isPeriod ? val : inp.monthNames[val] + ' ' + inp.currentYear) + ' </br>') ) + '</strong></h3><span>' + '</span></div>';
+
+    return heading + '<table class="tooltipTableLCCenter"><tr><td><div class="containerTT"><div class="col left alignCenter">' + leftStr + '</div><div class="col right alignCenter">' + rightStr + '</div></div></td></tr></table>'
+  }
+
+  const getTooltipFragmentState = (param) => {
+  
+    let val = isPeriod ? inp.monthNamesPeriod[param] : param;
+    let numStates = getNumberOfStates(param)
+    var leftComStr = `<table><tr><td><p class='whSpace'><strong>` + inp.stateNames[compareState] + '</strong></br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;' + '</p></td></tr>';
+    var leftRateStr = `<tr><td><p><strong>Rate</strong>` + '</br>' + getRateHTMLforDrug(inp.selectedDrugs, compareState, val) + '</p></td></tr>';
+    var leftCountStr = `<tr><td><p><strong>Count</strong>` + '</br>' + getCountHTMLforDrug(inp.selectedDrugs, compareState, val) + '</p></td></tr></table>';
     var leftStr = leftComStr + leftRateStr + leftCountStr;
     var rightComStr = `<table><tr><td><p class='whSpace'><strong>` + inp.stateNames[inp.currentState] + '</strong></br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;' + '</p></td></tr>';
     var rightRateStr = `<tr><td><p><strong>Rate</strong>` + '</br>' + getRateHTMLforDrug(inp.selectedDrugs, inp.currentState, val) + '</p></td></tr>';
@@ -843,7 +860,7 @@ function LineChart({ params }) {
               height={specs.yMax}
               style={{outline: 'none'}}
               fill='transparent'
-              data-tip={(inp.currentState !== 'US' && showOverall) ? getTooltipFragment(d[specs.xKey]) : `<table class='tooltipTableLC'><tr><td><span class='toolTipSpanLC'><strong>${isPeriod ? `${inp.monthNamesPeriod[d[specs.xKey]]}` : inp.currentTimeframe === 'Monthly' ? `${inp.monthNames[d[specs.xKey]]} ${inp.currentYear}` : d[specs.xKey]}</strong></span>${tooltipValuesSorted.join('')}</td></tr></table>`}></rect>
+              data-tip={(showCompare) ? getTooltipFragmentState(d[specs.xKey]) : `<table class='tooltipTableLC'><tr><td><span class='toolTipSpanLC'><strong>${isPeriod ? `${inp.monthNamesPeriod[d[specs.xKey]]}` : inp.currentTimeframe === 'Monthly' ? `${inp.monthNames[d[specs.xKey]]} ${inp.currentYear}` : d[specs.xKey]}</strong></span>${tooltipValuesSorted.join('')}</td></tr></table>`}></rect>
           })
         }
       </Fragment>
@@ -1406,7 +1423,7 @@ function LineChart({ params }) {
                   </Group>)
                   }
                   {
-                    !showPercent && buildToolTipValues(sectionWidth, sectionWidthHalf)
+                    !showPercent && buildToolTipValuesState(sectionWidth, sectionWidthHalf)
                   }
                   {
                     showPercent && 
@@ -1545,7 +1562,7 @@ function LineChart({ params }) {
     {accessible ? (
         <>
         <DataTable508
-          data={AccessibilityFunctions.generateLineChartData(data.state, filteredData, currentDataSource, countsDataYearly, countsDataMonthly, currentDrug, selectedDrugs, currentState, stateNames, currentTimeframe, showPercent, showCount, changePrecValues)}
+          data={AccessibilityFunctions.generateLineChartData(data.state, filteredData, currentDataSource, countsDataYearly, countsDataMonthly, currentDrug, selectedDrugs, currentState, stateNames, currentTimeframe, showPercent, showCount, showOverall, changePrecValues)}
           labelOverrides={showPercent ? {
             'alldrug': 'All Drugs rate',
             'benzodiazepine': 'Benzodiazepine rate',

--- a/src/components/LineChart.js
+++ b/src/components/LineChart.js
@@ -65,6 +65,29 @@ const getCountsYearly = (data, currentDataSource, drugOptions) => {
   return arr;
 }
 
+const getCountsYearlyState = (data, currentDataSource, currentDrug, compareState) => {
+
+  var arr = [];
+
+  for (let i=0; i<data.state[currentDataSource][currentDrug]['all'].length; i++)
+  {
+    if (data.state[currentDataSource][currentDrug]['all'][i].state == compareState)
+    {
+      Object.keys(data.state[currentDataSource][currentDrug]['all'][i]).forEach(rec => {
+        arr.push({
+          year: rec,
+          drug: currentDrug,
+          count: data.state[currentDataSource][currentDrug]['all'][i][rec],
+        });
+      })
+      
+    } 
+    
+  }
+
+  return arr;
+}
+
 const getCountsMonthly = (data, currentDataSource, drugOptions) => {
   var arr = [];
 
@@ -92,6 +115,34 @@ const getCountsMonthly = (data, currentDataSource, drugOptions) => {
       }
     })
   })
+  return arr;
+}
+
+const getCountsMonthlyState = (data, currentDataSource, currentDrug, compareState) => {
+  var arr = [];
+
+  Object.keys(data.state[currentDataSource][currentDrug]).forEach(mon => {
+    if (!isNaN(mon)) {
+      for (let i=0; i<Object.keys(data.state[currentDataSource][currentDrug][mon]).length; i++)
+      {
+          if (data.state[currentDataSource][currentDrug][mon][i].state == compareState)
+          {
+            for (let j=0; j<Object.keys(data.state[currentDataSource][currentDrug][mon][i]).length; j++)
+            {
+              if (Object.keys(data.state[currentDataSource][currentDrug][mon][i])[j] != 'state') {
+                arr.push({
+                  year: Object.keys(data.state[currentDataSource][currentDrug][mon][i])[j],
+                  month: mon,
+                  drug: currentDrug,
+                  count: data.state[currentDataSource][currentDrug][mon][i][Object.keys(data.state[currentDataSource][currentDrug][mon][i])[j]],
+                });
+              }
+            }
+        }
+      } 
+    }
+  })
+
   return arr;
 }
 
@@ -214,8 +265,8 @@ function LineChart({ params }) {
   if (showCompare && compareState !== null) 
     filteredData[compareState] = isPeriod || (accessible && currentTimeframe == 'Monthly') ? getFilteredDataPeriod(data, currentDataSource, compareState, lookupPeriodStartYear, lookupPeriodStartMonth, lookupPeriodEndYear, lookupPeriodEndMonth) : getFilteredData(data, currentTimeframe, currentDataSource, compareState, currentYear)
 
-  const countsDataYearly = getCountsYearly(data.sex, currentDataSource, drugOptions);
-  const countsDataMonthly = getCountsMonthly(data.sex, currentDataSource, drugOptions);
+  const countsDataYearly = !showCompare ? getCountsYearly(data.sex, currentDataSource, drugOptions) : getCountsYearlyState(data, currentDataSource, currentDrug, compareState);
+  const countsDataMonthly = !showCompare ? getCountsMonthly(data.sex, currentDataSource, drugOptions) : getCountsMonthlyState(data, currentDataSource, currentDrug, compareState);
   
   const yScaleDomainPeriod = (showCompare || showOverall) ? (UtilityFunctions.calculateYScaleDomainCompare(filteredData, currentDrug, currentState, compareState) * 1.2) : (UtilityFunctions.calculateYScaleDomain(filteredData, currentDrug, selectedDrugs, currentState, showOverall) * 1.2);
 
@@ -1436,6 +1487,60 @@ function LineChart({ params }) {
       )
   }
 
+  const getColSpan = () => {
+
+    if (showOverall) {
+      if (showCount)
+        return 2;
+      if (!showCount)
+        return 4;
+    }
+
+    if (showPercent)
+    {
+      if (showCompare)
+        return 4;
+      else
+        return selectedDrugs.length * 2;
+    }
+
+    if (showCompare)
+    {
+      if (showPercent)
+        return 4;
+      else
+        return 2;
+
+    }
+
+    if (showCount && !showOverall)
+    {
+        return selectedDrugs.length;
+    }
+  }
+
+  const getColSpan2 = () => {
+
+    if (showCount)
+    {
+      if (showOverall)
+      {
+        return 4;
+      }
+      else
+      {
+        if (showCompare)
+          return 2;
+        else
+          return selectedDrugs.length;
+      }
+    }
+    else
+    {
+      return null;
+    }
+  }
+
   const buildLineForDrugState = (currentDrug) => {
 
     const sectionWidth = specs.xMax / specs.xValues.length;
@@ -1562,7 +1667,7 @@ function LineChart({ params }) {
     {accessible ? (
         <>
         <DataTable508
-          data={AccessibilityFunctions.generateLineChartData(data.state, filteredData, currentDataSource, countsDataYearly, countsDataMonthly, currentDrug, selectedDrugs, currentState, stateNames, currentTimeframe, showPercent, showCount, showOverall, changePrecValues)}
+          data={AccessibilityFunctions.generateLineChartData(data.state, filteredData, currentDataSource, countsDataYearly, countsDataMonthly, currentDrug, selectedDrugs, currentState, stateNames, currentTimeframe, showCompare, showOverall, showPercent, showCount, compareState, changePrecValues)}
           labelOverrides={showPercent ? {
             'alldrug': 'All Drugs rate',
             'benzodiazepine': 'Benzodiazepine rate',
@@ -1572,7 +1677,7 @@ function LineChart({ params }) {
             'opioid': 'All Opioids rate',
             'stimulant': 'All Stimulants rate',
             'fentanyl': 'Fentanyl rate',
-            'Overall': 'Overall rate',
+            'Overall': !showCompare ? 'Overall rate' : stateNames[compareState] + ' rate',
             'alldrug_pct': 'All Drugs %change in rate',
             'benzodiazepine_pct': 'Benzodiazepine %change in rate',
             'cocaine_pct': 'Cocaine %change in rate',
@@ -1581,7 +1686,7 @@ function LineChart({ params }) {
             'opioid_pct': 'All Opioids %change in rate',
             'stimulant_pct': 'All Stimulants %change in rate',
             'fentanyl_pct': 'Fentanyl %change in rate',
-            'Overall_pct': 'Overall %change in rate',
+            'Overall_pct': !showCompare ? 'Overall' : stateNames[compareState] + ' %change in rate',
             'state' : currentStaterate,
             'state_pct' : currentStatePctChange,
             'Year/Month': currentTimeframe == 'Monthly' ? 'Month and Year' : 'Year',
@@ -1594,7 +1699,7 @@ function LineChart({ params }) {
             'opioid': 'All Opioids',
             'stimulant': 'All Stimulants',
             'fentanyl': 'Fentanyl',
-            'Overall': 'Overall',
+            'Overall': !showCompare ? 'Overall' : stateNames[compareState],
             'state' : currentStaterate,
             'alldrug_cnt': 'All Drugs',
             'benzodiazepine_cnt': 'Benzodiazepine',
@@ -1604,7 +1709,7 @@ function LineChart({ params }) {
             'opioid_cnt': 'All Opioids',
             'stimulant_cnt': 'All Stimulants',
             'fentanyl_cnt': 'Fentanyl',
-            'Overall_cnt': 'Overall',
+            'Overall_cnt': !showCompare ? 'Overall' : stateNames[compareState],
             'state_cnt' : currentStateCnt,
           } : {
             'alldrug': 'All Drugs',
@@ -1615,7 +1720,7 @@ function LineChart({ params }) {
             'opioid': 'All Opioids',
             'stimulant': 'All Stimulants',
             'fentanyl': 'Fentanyl',
-            'Overall': 'Overall',
+            'Overall': !showCompare ? 'Overall' : stateNames[compareState],
             'state' : currentStaterate,
             'Year/Month': currentTimeframe == 'Monthly' ? 'Month and Year' : 'Year',
           }}
@@ -1624,8 +1729,8 @@ function LineChart({ params }) {
             rate: num => UtilityFunctions.toFixed(num)
           }}
           width={width}
-          colSpan={(showPercent) ? ((currentState == 'US' ? (showPercent ? (selectedDrugs.length * 2) : selectedDrugs.length) : ((showPercent) ? 4: 2))) : (currentState == 'US' ? selectedDrugs.length : 2)}
-          colSpan2={(showCount) ? ((currentState == 'US' ? (showCount ? (selectedDrugs.length * 2) : selectedDrugs.length) : ((showCount) ? 4: 2))) : null}
+          colSpan={getColSpan()}
+          colSpan2={getColSpan2()}
           isSmallViewport={specs['isSmallViewport']}
           supScript={showPercent ?'§': ''}
           noSort={true}

--- a/src/components/LineChart.js
+++ b/src/components/LineChart.js
@@ -416,6 +416,16 @@ function LineChart({ params }) {
               adjusted: false
             })
         }
+        else
+        {
+          positionsVar.push({
+              label: drugOptions[selectedDrugs[i]].titleForDropDown, 
+              xpos: specs.xMax + 18,
+              ypos:  specs.yScale(0),
+              yposNew: specs.yScale(0),
+              adjusted: false
+            })
+        }
       }
     }
     
@@ -469,7 +479,6 @@ function LineChart({ params }) {
       }
     }
     
-
     specs['positionsVar'] = positionsVar;
 
     for (var i=0; i<allLabels?.length; i++) {
@@ -881,25 +890,25 @@ function LineChart({ params }) {
             if (inp.currentState === currentState) {
               let numStates = getNumberOfStates(d[specs.xKey])
               let cntC = getCountforDrug(currentDrug, currentState, currentTimeframe == 'Annual' ? d['year'] : (!isPeriod ? d['month'] : inp.monthNamesPeriod[d['index']]));
+              let cntCFinal = isNaN(cntC) ? cntC : Number(cntC).toLocaleString('en-US');
               var tooltipValues = [];
               if (!currentDrugOnly) {
                 tooltipValues.push(`<p><strong class=${currentDrug + 'ToolTip'}>` + drugOptions[currentDrug].titleForDropDown + ` Rate</strong>: ${d[currentDrug]}</p>`);
-                tooltipValues.push(`<p><strong class=${currentDrug + 'ToolTip'}>` + drugOptions[currentDrug].titleForDropDown + ` Count</strong>: ${cntC}</p>`);
+                tooltipValues.push(`<p><strong class=${currentDrug + 'ToolTip'}>` + drugOptions[currentDrug].titleForDropDown + ` Count</strong>: ${cntCFinal}` + get2024FootNote(d['year'], cntC) + `</p>`);
               }
 
               if (inp.selectedDrugs.length > 0) {
                   for (var i in inp.selectedDrugs) {
                     let cntS = getCountforDrug(inp.selectedDrugs[i], currentState, currentTimeframe == 'Annual' ? d['year'] : (!isPeriod ? d['month'] : inp.monthNamesPeriod[d['index']]));
+                    let cntSFinal = isNaN(cntS) ? cntS : Number(cntS).toLocaleString('en-US');
                     if (!inp.selectedDrugs[i].includes(currentDrug)){
                       tooltipValues.push(!currentDrugOnly ? `<p><strong class=${inp.selectedDrugs[i] + 'ToolTip'}>` + drugOptions[inp.selectedDrugs[i]].titleForDropDown + ` Rate</strong>: ${d[inp.selectedDrugs[i]]}</p>` : null);
-                      tooltipValues.push(!currentDrugOnly ? `<p><strong class=${inp.selectedDrugs[i] + 'ToolTip'}>` + drugOptions[inp.selectedDrugs[i]].titleForDropDown + ` Count</strong>: ${cntS}</p>` : null);
+                      tooltipValues.push(!currentDrugOnly ? `<p><strong class=${inp.selectedDrugs[i] + 'ToolTip'}>` + drugOptions[inp.selectedDrugs[i]].titleForDropDown + ` Count</strong>: ${cntSFinal}` + get2024FootNote(d['year'], cntS) + `</p>` : null);
                     }
                   }
               }
             }
             
-            
-
             let tooltipValuesSorted = sortToolTipValues(tooltipValues)
 
             return <rect
@@ -967,12 +976,12 @@ function LineChart({ params }) {
     }
   }
 
-  function getLastKnownDataPoint() {
+  function getLastKnownDataPoint(curDrug) {
     let val = 0;
     for (var i=inp.filteredData[inp.currentState].length - 1;i>0;i--)
     {
-      if (!isNaN(inp.filteredData[inp.currentState][i][currentDrug])) {
-        val = inp.filteredData[inp.currentState][i][currentDrug];
+      if (!isNaN(inp.filteredData[inp.currentState][i][curDrug])) {
+        val = inp.filteredData[inp.currentState][i][curDrug];
         break;
       }
     }
@@ -1548,7 +1557,7 @@ function LineChart({ params }) {
 
     const seriesLabelPositionUS = specs.yScale(inp.filteredData['US'][inp.filteredData['US'].length - 1][currentDrug]);
     const valueState = inp.filteredData[inp.currentState].length > 0 ? inp.filteredData[inp.currentState][inp.filteredData[inp.currentState].length - 1][currentDrug] : 'Data suppressed*';
-    const seriesLabelPositionState = valueState === 'Data suppressed*' ? getLastKnownDataPoint() == 0 ? specs.yScale(0) - 30 : specs.yScale(getLastKnownDataPoint()) : specs.yScale(valueState);
+    const seriesLabelPositionState = valueState === 'Data suppressed*' ? getLastKnownDataPoint(currentDrug) == 0 ? specs.yScale(0) - 30 : specs.yScale(getLastKnownDataPoint(currentDrug)) : specs.yScale(valueState);
     
     if (seriesLabelPositionUS === undefined)
       return;
@@ -1686,7 +1695,7 @@ function LineChart({ params }) {
             'opioid_pct': 'All Opioids %change in rate',
             'stimulant_pct': 'All Stimulants %change in rate',
             'fentanyl_pct': 'Fentanyl %change in rate',
-            'Overall_pct': !showCompare ? 'Overall' : stateNames[compareState] + ' %change in rate',
+            'Overall_pct': (!showCompare ? 'Overall' : stateNames[compareState]) + ' %change in rate',
             'state' : currentStaterate,
             'state_pct' : currentStatePctChange,
             'Year/Month': currentTimeframe == 'Monthly' ? 'Month and Year' : 'Year',

--- a/src/components/LineChart.js
+++ b/src/components/LineChart.js
@@ -1545,7 +1545,7 @@ function LineChart({ params }) {
     {accessible ? (
         <>
         <DataTable508
-          data={AccessibilityFunctions.generateLineChartData(filteredData, currentDrug, selectedDrugs, currentState, stateNames, currentTimeframe, showPercent, changePrecValues)}
+          data={AccessibilityFunctions.generateLineChartData(data.state, filteredData, currentDataSource, countsDataYearly, countsDataMonthly, currentDrug, selectedDrugs, currentState, stateNames, currentTimeframe, showPercent, showCount, changePrecValues)}
           labelOverrides={showPercent ? {
             'alldrug': 'All Drugs rate',
             'benzodiazepine': 'Benzodiazepine rate',

--- a/src/components/LineChart.js
+++ b/src/components/LineChart.js
@@ -200,7 +200,7 @@ const getFilteredDataPeriod = (data, currentDataSource, currentState, lookupPeri
 
 function LineChart({ params }) {
 
-  const { data, monthNames, stateNames, drugOptions, currentTimeframe, currentDataSource, currentDrug, currentState, currentYear: currentYearUntyped, currentMonth, width, stateDropdownOptions, lookupPeriodStartYear, lookupPeriodStartMonth, lookupPeriodEndYear, lookupPeriodEndMonth, showLabels, showPercent, showCount, isPeriod, currentDrugOnly, supportedYears, selectedDrugs, accessible } = params;
+  const { data, monthNames, stateNames, drugOptions, currentTimeframe, currentDataSource, currentDrug, currentState, currentYear: currentYearUntyped, currentMonth, width, stateDropdownOptions, lookupPeriodStartYear, lookupPeriodStartMonth, lookupPeriodEndYear, lookupPeriodEndMonth, showLabels, showOverall, showCompare, compareState, showPercent, showCount, isPeriod, currentDrugOnly, supportedYears, selectedDrugs, accessible } = params;
 
   const currentYear = parseInt(currentYearUntyped);
 
@@ -211,13 +211,16 @@ function LineChart({ params }) {
   if (currentState !== 'US') 
     filteredData['US'] = isPeriod || (accessible && currentTimeframe == 'Monthly') ? getFilteredDataPeriod(data, currentDataSource, 'US', lookupPeriodStartYear, lookupPeriodStartMonth, lookupPeriodEndYear, lookupPeriodEndMonth) : getFilteredData(data, currentTimeframe, currentDataSource, 'US', currentYear)
 
+  if (showCompare && compareState !== null) 
+    filteredData[compareState] = isPeriod || (accessible && currentTimeframe == 'Monthly') ? getFilteredDataPeriod(data, currentDataSource, compareState, lookupPeriodStartYear, lookupPeriodStartMonth, lookupPeriodEndYear, lookupPeriodEndMonth) : getFilteredData(data, currentTimeframe, currentDataSource, compareState, currentYear)
+
   const countsDataYearly = getCountsYearly(data.sex, currentDataSource, drugOptions);
   const countsDataMonthly = getCountsMonthly(data.sex, currentDataSource, drugOptions);
   
-  const yScaleDomainPeriod = (UtilityFunctions.calculateYScaleDomain(filteredData, currentDrug, selectedDrugs, currentState) * 1.2);
+  const yScaleDomainPeriod = showCompare ? (UtilityFunctions.calculateYScaleDomainCompare(filteredData, currentDrug, currentState, compareState) * 1.2) : (UtilityFunctions.calculateYScaleDomain(filteredData, currentDrug, selectedDrugs, currentState, showOverall) * 1.2);
 
   const currentStaterate = stateNames[currentState];
-  const currentStatePctChange = stateNames[currentState] + ' %change in rate'
+  const currentStatePctChange = stateNames[currentState] + ' %change in rate';
   const currentStateCnt = stateNames[currentState];
 
   useEffect(() => {
@@ -348,20 +351,17 @@ function LineChart({ params }) {
 
  const adjustCrowdedLabels = () => {
 
-  if (currentState != 'US')
-    return;
-
     var positionsVar = [];
     const allLabels = document?.getElementsByClassName("adjustCrowded");
     if (selectedDrugs !== undefined && selectedDrugs != null) {
       for (var i=0; i<selectedDrugs?.length; i++) {
-        var pos = specs.yScale(inp.filteredData['US'][inp.filteredData['US'].length - 1][selectedDrugs[i]]);
+        var pos = specs.yScale(inp.filteredData[currentState][inp.filteredData[currentState].length - 1][selectedDrugs[i]]);
         if (pos !== undefined) {
           positionsVar.push({
               label: drugOptions[selectedDrugs[i]].titleForDropDown, 
               xpos: specs.xMax + 18,
-              ypos:  specs.yScale(inp.filteredData['US'][inp.filteredData['US'].length - 1][selectedDrugs[i]]),
-              yposNew: specs.yScale(inp.filteredData['US'][inp.filteredData['US'].length - 1][selectedDrugs[i]]),
+              ypos:  specs.yScale(inp.filteredData[currentState][inp.filteredData[currentState].length - 1][selectedDrugs[i]]),
+              yposNew: specs.yScale(inp.filteredData[currentState][inp.filteredData[currentState].length - 1][selectedDrugs[i]]),
               adjusted: false
             })
         }
@@ -432,9 +432,6 @@ function LineChart({ params }) {
   }
 
   const adjustLinesForLabels = () => {
-
-    if (currentState != 'US')
-      return;
 
     if (selectedDrugs !== undefined && selectedDrugs != null) {
       for (var i=0; i<selectedDrugs?.length; i++) {
@@ -758,7 +755,7 @@ function LineChart({ params }) {
     
     return false;
   }
-  
+
   const buildToolTipValues = (sectionWidth, sectionWidthHalf) => {
     return (
       <Fragment>
@@ -799,6 +796,54 @@ function LineChart({ params }) {
               style={{outline: 'none'}}
               fill='transparent'
               data-tip={inp.currentState !== 'US' ? getTooltipFragment(d[specs.xKey]) : `<table class='tooltipTableLC'><tr><td><span class='toolTipSpanLC'><strong>${isPeriod ? `${inp.monthNamesPeriod[d[specs.xKey]]}` : inp.currentTimeframe === 'Monthly' ? `${inp.monthNames[d[specs.xKey]]} ${inp.currentYear}` : d[specs.xKey]}</strong></span>${tooltipValuesSorted.join('')}</td></tr></table>`}></rect>
+          })
+        }
+      </Fragment>
+    )
+  }
+
+  const buildToolTipValuesState = (sectionWidth, sectionWidthHalf) => {
+
+    return (
+      <Fragment>
+        {
+          
+          inp.filteredData[currentState].map(d => {
+
+            if (inp.currentState === currentState) {
+              let numStates = getNumberOfStates(d[specs.xKey])
+              let cntC = getCountforDrug(currentDrug, currentState, currentTimeframe == 'Annual' ? d['year'] : (!isPeriod ? d['month'] : inp.monthNamesPeriod[d['index']]));
+              var tooltipValues = [];
+              if (!currentDrugOnly) {
+                tooltipValues.push(`<p><strong class=${currentDrug + 'ToolTip'}>` + drugOptions[currentDrug].titleForDropDown + ` Rate</strong>: ${d[currentDrug]}</p>`);
+                tooltipValues.push(`<p><strong class=${currentDrug + 'ToolTip'}>` + drugOptions[currentDrug].titleForDropDown + ` Count</strong>: ${cntC}</p>`);
+              }
+
+              if (inp.selectedDrugs.length > 0) {
+                  for (var i in inp.selectedDrugs) {
+                    let cntS = getCountforDrug(inp.selectedDrugs[i], currentState, currentTimeframe == 'Annual' ? d['year'] : (!isPeriod ? d['month'] : inp.monthNamesPeriod[d['index']]));
+                    if (!inp.selectedDrugs[i].includes(currentDrug)){
+                      tooltipValues.push(!currentDrugOnly ? `<p><strong class=${inp.selectedDrugs[i] + 'ToolTip'}>` + drugOptions[inp.selectedDrugs[i]].titleForDropDown + ` Rate</strong>: ${d[inp.selectedDrugs[i]]}</p>` : null);
+                      tooltipValues.push(!currentDrugOnly ? `<p><strong class=${inp.selectedDrugs[i] + 'ToolTip'}>` + drugOptions[inp.selectedDrugs[i]].titleForDropDown + ` Count</strong>: ${cntS}</p>` : null);
+                    }
+                  }
+              }
+            }
+            
+            
+
+            let tooltipValuesSorted = sortToolTipValues(tooltipValues)
+
+            return <rect
+              key={`tooltip-section-${d[specs.xKey]}`}
+              className={''}
+              x={Math.max(0, specs.xScale(d[specs.xKey]) - sectionWidthHalf)}
+              y={0}
+              width={sectionWidth}
+              height={specs.yMax}
+              style={{outline: 'none'}}
+              fill='transparent'
+              data-tip={(inp.currentState !== 'US' && showOverall) ? getTooltipFragment(d[specs.xKey]) : `<table class='tooltipTableLC'><tr><td><span class='toolTipSpanLC'><strong>${isPeriod ? `${inp.monthNamesPeriod[d[specs.xKey]]}` : inp.currentTimeframe === 'Monthly' ? `${inp.monthNames[d[specs.xKey]]} ${inp.currentYear}` : d[specs.xKey]}</strong></span>${tooltipValuesSorted.join('')}</td></tr></table>`}></rect>
           })
         }
       </Fragment>
@@ -888,6 +933,9 @@ function LineChart({ params }) {
   }
 
   function lastValuesNarrow() {
+    if (!showOverall)
+      return false;
+
     var stVal = inp.filteredData[currentState][inp.filteredData[currentState].length - 1][currentDrug];
     var usVal = inp.filteredData['US'][inp.filteredData[currentState].length - 1][currentDrug];
     const usValF = parseFloat(specs.yScale(parseFloat(usVal)));
@@ -905,12 +953,36 @@ function LineChart({ params }) {
       return false;
   }
 
+  function lastValuesNarrowCompareState() {
+    if (!showCompare)
+      return false;
+
+    var stVal = inp.filteredData[currentState][inp.filteredData[currentState].length - 1][currentDrug];
+    var compareStVal = inp.filteredData[compareState][inp.filteredData[currentState].length - 1][currentDrug];
+    const compareStValF = parseFloat(specs.yScale(parseFloat(compareStVal)));
+    const stValF = parseFloat(specs.yScale(parseFloat(stVal)));
+
+    var diff;
+    if (compareStValF > stValF)
+      diff = compareStValF - stValF;
+    else
+      diff = stValF - compareStValF;
+
+    if (diff <= 15)
+      return true;
+    else
+      return false;
+  }
+
   function lastValue() {
     var stVal = inp.filteredData[currentState][inp.filteredData[currentState].length - 1][currentDrug];
     return specs.yScale(parseFloat(stVal));
   }
 
   function narrowPoints(xval) {
+
+    if (!showOverall)
+      return false;
 
     const usVal = inp.filteredData['US'].find(d => d[specs.xKey] === xval) || {};
     const stVal = inp.filteredData[currentState].find(d => d[specs.xKey] === xval) || {};
@@ -929,12 +1001,48 @@ function LineChart({ params }) {
       return false;
   }
 
+  function narrowPointsCompareState(xval) {
+
+    if (!showCompare)
+      return false;
+
+    const compareStVal = inp.filteredData[compareState].find(d => d[specs.xKey] === xval) || {};
+    const stVal = inp.filteredData[currentState].find(d => d[specs.xKey] === xval) || {};
+    const compareStValF = parseFloat(specs.yScale(parseFloat(compareStVal[currentDrug])));
+    const stValF = parseFloat(specs.yScale(parseFloat(stVal[currentDrug])));
+
+    var diff;
+    if (compareStValF > stValF)
+      diff = compareStValF - stValF;
+    else
+      diff = stValF - compareStValF;
+
+    if (diff <= 15)
+      return true;
+    else
+      return false;
+  }
+
   function higherValue(xval) {
+    if (!showOverall)
+      return false;
 
     const usVal = inp.filteredData['US'].find(d => d[specs.xKey] === xval) || {};
     const stVal = inp.filteredData[currentState].find(d => d[specs.xKey] === xval) || {};
     if (parseFloat(usVal[currentDrug]) > parseFloat(stVal[currentDrug]))
       return 'US';
+    else
+      return currentState;
+  }
+
+  function higherValueCompareState(xval) {
+    if (!showCompare)
+      return false;
+
+    const compareStVal = inp.filteredData[compareState].find(d => d[specs.xKey] === xval) || {};
+    const stVal = inp.filteredData[currentState].find(d => d[specs.xKey] === xval) || {};
+    if (parseFloat(compareStVal[currentDrug]) > parseFloat(stVal[currentDrug]))
+      return compareState;
     else
       return currentState;
   }
@@ -954,7 +1062,7 @@ function LineChart({ params }) {
     return (
       <Fragment>
           <Group>
-                  {Object.keys(inp.filteredData).map(key => <Group key={`line-path-${key}`}>
+                  {Object.keys(inp.filteredData).filter(d => d == 'US' || d == currentState).map(key => <Group key={`line-path-${key}`}>
                     {specs.xValues.map((xVal, i) => {
                       const d = inp.filteredData[key].find(d => d[specs.xKey] === xVal) || {};
                       const dNext = i === specs.xValues.length - 1 ? {} : inp.filteredData[key].find(d => d[specs.xKey] === specs.xValues[i + 1]) || {}
@@ -963,7 +1071,7 @@ function LineChart({ params }) {
                       return (
                         <Group key={`line-path-${key}-point-${i}`}>
                           {(!isNaN(d[currentDrug]) && !isNaN(dNext[currentDrug]) && key == 'US') && 
-                            <line x1={specs.xScale(d[specs.xKey]) ?? 0} y1={getYValue(d, currentDrug)} x2={specs.xScale(dNext[specs.xKey]) ?? 0} y2={getYValue(dNext, currentDrug)} stroke={UtilityFunctions.getSeriesColorLine(currentDrug, key, true)} strokeWidth={3} />
+                            <line x1={specs.xScale(d[specs.xKey]) ?? 0} y1={getYValue(d, currentDrug)} x2={specs.xScale(dNext[specs.xKey]) ?? 0} y2={getYValue(dNext, currentDrug)} stroke={UtilityFunctions.getSeriesColorLine(currentDrug, key, showOverall ? true :false)} strokeWidth={3} />
                           }
                           {(!isNaN(d[currentDrug]) && !isNaN(dNext[currentDrug]) && key != 'US') && 
                             <line x1={specs.xScale(d[specs.xKey]) ?? 0} y1={getYValue(d, currentDrug)} x2={specs.xScale(dNext[specs.xKey]) ?? 0} y2={getYValue(dNext, currentDrug)} stroke={UtilityFunctions.getSeriesColorLine(currentDrug, key, false)} strokeWidth={3} />
@@ -999,7 +1107,7 @@ function LineChart({ params }) {
                           />
                           }
                           {(isNaN(d[currentDrug]) && key == 'US') && <text x={i == 0 ? specs.xScale(d[specs.xKey]) :  specs.xScale(d[specs.xKey])} y={specs.yScale(0)-8} stroke={''} fill={''} fontSize={16} textAnchor={'middle'}>{getSymbol(d[currentDrug])}</text>}
-                          {(!isNaN(d[currentDrug]) && key == 'US') && <Circle cx={specs.xScale(d[specs.xKey])} cy={Number(d[currentDrug]) == 0 ? (specs.yScale(0)-14) : (specs.yScale(d[currentDrug]))} r={currentTimeframe === 'Monthly' ? 4: 5} fill={currentTimeframe === 'Monthly' && d[specs.xKey] == currentMonth ? 'orange' : UtilityFunctions.getSeriesColorLine(currentDrug, key, true)} />}
+                          {(!isNaN(d[currentDrug]) && key == 'US') && <Circle cx={specs.xScale(d[specs.xKey])} cy={Number(d[currentDrug]) == 0 ? (specs.yScale(0)-14) : (specs.yScale(d[currentDrug]))} r={currentTimeframe === 'Monthly' ? 4: 5} fill={currentTimeframe === 'Monthly' && d[specs.xKey] == currentMonth ? 'orange' : UtilityFunctions.getSeriesColorLine(currentDrug, key, showOverall ? true :false)} />}
                           {(!isNaN(d[currentDrug]) && key != 'US') && currentState == 'US' &&
                             <text 
                               x={i == 0 ? specs.xScale(d[specs.xKey]) :  specs.xScale(d[specs.xKey])} 
@@ -1101,7 +1209,7 @@ function LineChart({ params }) {
                                 y={yPos}
                                 alignmentBaseline="middle" 
                                 fontSize={specs.fontSize} 
-                                fill={UtilityFunctions.getSeriesColorLine(currentDrug, key,true)}>
+                                fill={UtilityFunctions.getSeriesColorLine(currentDrug, key, false)}>
                                   {drugOptions[currentDrug].titleForDropDown}
                               </text>
                             </Group>
@@ -1125,12 +1233,319 @@ function LineChart({ params }) {
       )
   }
 
+  const buildLineForDrugStateCompare = (currentDrug) => {
+
+    const sectionWidth = specs.xMax / specs.xValues.length;
+    const sectionWidthHalf = sectionWidth / 2;
+
+    const seriesLabelPositionCompareState = specs.yScale(inp.filteredData[compareState][inp.filteredData[compareState].length - 1][currentDrug]);
+    const valueState = inp.filteredData[inp.currentState].length > 0 ? inp.filteredData[inp.currentState][inp.filteredData[inp.currentState].length - 1][currentDrug] : 'Data suppressed*';
+    const seriesLabelPositionState = valueState === 'Data suppressed*' ? getLastKnownDataPoint() == 0 ? specs.yScale(0) - 30 : specs.yScale(getLastKnownDataPoint()) : specs.yScale(valueState);
+    
+    if (seriesLabelPositionCompareState === undefined)
+      return;
+    
+    return (
+      <Fragment>
+          <Group>
+                  {Object.keys(inp.filteredData).filter(d => d == compareState || d == currentState).map(key => <Group key={`line-path-${key}`}>
+                    {specs.xValues.map((xVal, i) => {
+                      const d = inp.filteredData[key].find(d => d[specs.xKey] === xVal) || {};
+                      const dNext = i === specs.xValues.length - 1 ? {} : inp.filteredData[key].find(d => d[specs.xKey] === specs.xValues[i + 1]) || {}
+                      const dPrev = i > 0  ? inp.filteredData[key].find(d => d[specs.xKey] === specs.xValues[i - 1]) || {} : {}
+
+                      return (
+                        <Group key={`line-path-${key}-point-${i}`}>
+                          {(!isNaN(d[currentDrug]) && !isNaN(dNext[currentDrug]) && key == compareState) && 
+                            <line x1={specs.xScale(d[specs.xKey]) ?? 0} y1={getYValue(d, currentDrug)} x2={specs.xScale(dNext[specs.xKey]) ?? 0} y2={getYValue(dNext, currentDrug)} stroke={UtilityFunctions.getSeriesColorLine(currentDrug, key, showOverall ? true :false)} strokeWidth={3} />
+                          }
+                          {(!isNaN(d[currentDrug]) && !isNaN(dNext[currentDrug]) && key != compareState) && 
+                            <line x1={specs.xScale(d[specs.xKey]) ?? 0} y1={getYValue(d, currentDrug)} x2={specs.xScale(dNext[specs.xKey]) ?? 0} y2={getYValue(dNext, currentDrug)} stroke={UtilityFunctions.getSeriesColorLine(currentDrug, key, false)} strokeWidth={3} />
+                          }
+                          {(!isNaN(d[currentDrug]) && key == compareState) && currentState == compareState &&
+                            <text 
+                              x={i == 0 ? specs.xScale(d[specs.xKey]) :  specs.xScale(d[specs.xKey])} 
+                              y={specs.yScale(d[currentDrug])-8}
+                              stroke={''} fill={''} 
+                              fontSize={12} textAnchor={i == 0 ? 'right' : 'middle'}>
+                                {showLabels ? d[currentDrug] : ''}
+                            </text>
+                          }
+                          {(!isNaN(d[currentDrug]) && key == compareState) && currentState != compareState && showLabels && 
+                            <text 
+                              x={i == 0 ? specs.xScale(d[specs.xKey]) :  specs.xScale(d[specs.xKey])} 
+                              y={!narrowPointsCompareState(xVal) ? specs.yScale(d[currentDrug])-8 : (higherValueCompareState(xVal) == compareState ? specs.yScale(d[currentDrug])-16 : specs.yScale(d[currentDrug])+28)} 
+                              stroke={''} fill={''} 
+                              fontSize={12} textAnchor={i == 0 ? 'right' : 'middle'}>
+                                {showLabels ? d[currentDrug] : ''}
+                            </text>
+                          }
+                          {(!isNaN(d[currentDrug]) && key == compareState && currentState != compareState && narrowPointsCompareState(xVal)) && showLabels && 
+                            <line
+                              x1={specs.xScale(d[specs.xKey])}
+                              y1={specs.yScale(d[currentDrug])}
+                              x2={specs.xScale(d[specs.xKey])}
+                              y2={higherValueCompareState(xVal) == compareState ? specs.yScale(d[currentDrug])-16 : specs.yScale(d[currentDrug]) + 18}
+                              stroke="#666"
+                              strokeWidth={0.7}
+                              strokeDasharray="2,2"
+                              opacity={0.6}
+                          />
+                          }
+                          {(isNaN(d[currentDrug]) && key == compareState) && <text x={i == 0 ? specs.xScale(d[specs.xKey]) :  specs.xScale(d[specs.xKey])} y={specs.yScale(0)-8} stroke={''} fill={''} fontSize={16} textAnchor={'middle'}>{getSymbol(d[currentDrug])}</text>}
+                          {(!isNaN(d[currentDrug]) && key == compareState) && <Circle cx={specs.xScale(d[specs.xKey])} cy={Number(d[currentDrug]) == 0 ? (specs.yScale(0)-14) : (specs.yScale(d[currentDrug]))} r={currentTimeframe === 'Monthly' ? 4: 5} fill={currentTimeframe === 'Monthly' && d[specs.xKey] == currentMonth ? 'orange' : UtilityFunctions.getSeriesColorLine(currentDrug, key, showOverall ? true :false)} />}
+                          {(!isNaN(d[currentDrug]) && key != compareState) && currentState == compareState &&
+                            <text 
+                              x={i == 0 ? specs.xScale(d[specs.xKey]) :  specs.xScale(d[specs.xKey])} 
+                              y={specs.yScale(d[currentDrug])-8}
+                              stroke={'lightblue'} fill={'lightblue'} 
+                              fontSize={12} 
+                              textAnchor={i == 0 ? 'right' : 'middle'}>
+                              {showLabels ? d[currentDrug] : ''}
+                            </text>
+                          }
+                          {(!isNaN(d[currentDrug]) && key != compareState) && currentState != compareState && showLabels && 
+                            <text 
+                              x={i == 0 ? specs.xScale(d[specs.xKey]) :  specs.xScale(d[specs.xKey])} 
+                              y={!narrowPoints(xVal) ? (d[currentDrug] == '0.0' ? specs.yScale(d[currentDrug])-22 : specs.yScale(d[currentDrug])-8) : (higherValue(xVal) == currentState ? specs.yScale(d[currentDrug])-16 : specs.yScale(d[currentDrug])+28)}
+                              stroke={UtilityFunctions.getSeriesColorLine(currentDrug, key, false)} fill={UtilityFunctions.getSeriesColorLine(currentDrug, key, false)} 
+                              strokeWidth={0.25}
+                              fontSize={12} 
+                              textAnchor={i == 0 ? 'right' : 'middle'}>
+                              {showLabels ? d[currentDrug] : ''}
+                            </text>
+                          }
+                          {(!isNaN(d[currentDrug]) && key != compareState & narrowPoints(xVal)) && currentState != compareState && showLabels && 
+                            <line
+                              x1={specs.xScale(d[specs.xKey])}
+                              y1={specs.yScale(d[currentDrug])}
+                              x2={specs.xScale(d[specs.xKey])}
+                              y2={higherValue(xVal) == currentState ? specs.yScale(d[currentDrug])-16 : specs.yScale(d[currentDrug]) + 18}
+                              stroke="#666"
+                              strokeWidth={0.7}
+                              strokeDasharray="2,2"
+                              opacity={0.6}
+                          />
+                          }
+                          {(isNaN(d[currentDrug]) && key != compareState) && 
+                          <text x={i == 0 ? specs.xScale(d[specs.xKey]) :  specs.xScale(d[specs.xKey])} y={specs.yScale(0)-8} fontSize={16} textAnchor={'middle'}>{getSymbol(d[currentDrug])}</text>}
+                          {(!isNaN(d[currentDrug]) && key != compareState) && 
+                          <Circle cx={specs.xScale(d[specs.xKey])} cy={Number(d[currentDrug]) == 0 ? (specs.yScale(0)-14) : (specs.yScale(d[currentDrug]))} r={currentTimeframe === 'Monthly' ? 4: 5} fill={currentTimeframe === 'Monthly' && d[specs.xKey] == currentMonth ? 'orange' : UtilityFunctions.getSeriesColorLine(currentDrug, key, false)} />}
+                        </Group>
+                      )
+                    })}
+                    {(!specs.isSmallViewport && yScaleDomainPeriod > 0) &&  (() => {
+                        let yPos = seriesLabelPositionCompareState;
+    
+                        if(key !== compareState) {
+
+                          const isOverlapping = seriesLabelPositionState < seriesLabelPositionCompareState + specs.seriesOverlapMargin && seriesLabelPositionState > seriesLabelPositionCompareState - specs.seriesOverlapMargin;
+                          if (isOverlapping) {
+                            if (seriesLabelPositionState < seriesLabelPositionCompareState) {
+                              yPos = seriesLabelPositionCompareState - specs.seriesSpacing;
+                              if(yPos < specs.seriesOverlapMargin){
+                                yPos = seriesLabelPositionCompareState + specs.seriesSpacing;
+                              }
+                            } else {
+                              yPos = seriesLabelPositionCompareState + specs.seriesSpacing;
+                              if(yPos > specs.yMax - specs.seriesOverlapMargin){
+                                yPos = seriesLabelPositionCompareState - specs.seriesSpacing;
+                              }
+                            }
+                          } else {
+                            yPos = seriesLabelPositionState;
+                          }
+                        }
+    
+                        if (currentState != compareState) {
+                          return (<Group>
+                            <text 
+                            x={specs.xMax + 25} 
+                            y={yPos}
+                            alignmentBaseline="middle" 
+                            fontSize={specs.fontSize} 
+                            fill={key != compareState ? UtilityFunctions.getSeriesColorLine(currentDrug, key, false) : UtilityFunctions.getSeriesColorLine(currentDrug, key, true)}>
+                              {key != compareState ? inp.stateNames[key] : inp.stateNames[compareState]}
+                          </text>
+                          {lastValuesNarrow() && key != compareState && <line
+                                id={`line-leading-${currentDrug}`}
+                                x1={specs.xMax + 4}
+                                y1={lastValue()}
+                                x2={specs.xMax + 25} 
+                                y2={yPos}
+                                stroke={UtilityFunctions.getSeriesColorLine(currentDrug, key, false)}
+                                strokeWidth={0.5}/>}
+                          </Group>
+                            )
+                        }
+                        else{
+                          return (
+                            <Group>
+                              <line
+                                id={`line-leading-${currentDrug}`}
+                                x1={specs.xMax + 4}
+                                y1={yPos}
+                                x2={specs.xMax + 25} 
+                                y2={yPos}
+                                stroke={colorScale[currentDrug]}
+                                strokeWidth={0.5}/>
+                              <text
+                                class='adjustCrowded'
+                                x={specs.xMax + 28} 
+                                y={yPos}
+                                alignmentBaseline="middle" 
+                                fontSize={specs.fontSize} 
+                                fill={UtilityFunctions.getSeriesColorLine(currentDrug, key, false)}>
+                                  {drugOptions[currentDrug].titleForDropDown}
+                              </text>
+                            </Group>
+                            )
+                        }
+                      })()
+                    }
+                  </Group>)
+                  }
+                  {
+                    !showPercent && buildToolTipValues(sectionWidth, sectionWidthHalf)
+                  }
+                  {
+                    showPercent && 
+                    inp.selectedDrugs.map(drug => {
+                      return buildToolTipValuesPerc(drug)
+                    })
+                  }
+                </Group>
+      </Fragment>
+      )
+  }
+
+  const buildLineForDrugState = (currentDrug) => {
+
+    const sectionWidth = specs.xMax / specs.xValues.length;
+    const sectionWidthHalf = sectionWidth / 2;
+
+    const seriesLabelPositionUS = specs.yScale(inp.filteredData['US'][inp.filteredData['US'].length - 1][currentDrug]);
+    const valueState = inp.filteredData[inp.currentState].length > 0 ? inp.filteredData[inp.currentState][inp.filteredData[inp.currentState].length - 1][currentDrug] : 'Data suppressed*';
+    const seriesLabelPositionState = valueState === 'Data suppressed*' ? getLastKnownDataPoint() == 0 ? specs.yScale(0) - 30 : specs.yScale(getLastKnownDataPoint()) : specs.yScale(valueState);
+    
+    if (seriesLabelPositionUS === undefined)
+      return;
+    
+    return (
+      <Fragment>
+          <Group>
+                  {Object.keys(inp.filteredData).filter(d => d == 'US' || d == currentState).map(key => <Group key={`line-path-${key}`}>
+                    {specs.xValues.map((xVal, i) => {
+                      const d = inp.filteredData[key].find(d => d[specs.xKey] === xVal) || {};
+                      const dNext = i === specs.xValues.length - 1 ? {} : inp.filteredData[key].find(d => d[specs.xKey] === specs.xValues[i + 1]) || {}
+                      const dPrev = i > 0  ? inp.filteredData[key].find(d => d[specs.xKey] === specs.xValues[i - 1]) || {} : {}
+
+                      return (
+                        <Group key={`line-path-${key}-point-${i}`}>
+                          {(!isNaN(d[currentDrug]) && !isNaN(dNext[currentDrug]) && key != 'US') && 
+                            <line x1={specs.xScale(d[specs.xKey]) ?? 0} y1={getYValue(d, currentDrug)} x2={specs.xScale(dNext[specs.xKey]) ?? 0} y2={getYValue(dNext, currentDrug)} stroke={UtilityFunctions.getSeriesColorLine(currentDrug, key, false)} strokeWidth={3} />
+                          }
+                          {(!isNaN(d[currentDrug]) && key == 'US') && currentState != 'US' && showLabels && 
+                            <text 
+                              x={i == 0 ? specs.xScale(d[specs.xKey]) :  specs.xScale(d[specs.xKey])} 
+                              y={!narrowPoints(xVal) ? specs.yScale(d[currentDrug])-8 : (higherValue(xVal) == 'US' ? specs.yScale(d[currentDrug])-16 : specs.yScale(d[currentDrug])+28)} 
+                              stroke={''} fill={''} 
+                              fontSize={12} textAnchor={i == 0 ? 'right' : 'middle'}>
+                                {showLabels && showOverall ? d[currentDrug] : ''}
+                            </text>
+                          }
+                          {(!isNaN(d[currentDrug]) && key == 'US' && currentState != 'US' && narrowPoints(xVal)) && showLabels && 
+                            <line
+                              x1={specs.xScale(d[specs.xKey])}
+                              y1={specs.yScale(d[currentDrug])}
+                              x2={specs.xScale(d[specs.xKey])}
+                              y2={higherValue(xVal) == 'US' ? specs.yScale(d[currentDrug])-16 : specs.yScale(d[currentDrug]) + 18}
+                              stroke="#666"
+                              strokeWidth={0.7}
+                              strokeDasharray="2,2"
+                              opacity={0.6}
+                          />
+                          }
+                          {(isNaN(d[currentDrug]) && key == 'US') && <text x={i == 0 ? specs.xScale(d[specs.xKey]) :  specs.xScale(d[specs.xKey])} y={specs.yScale(0)-8} stroke={''} fill={''} fontSize={16} textAnchor={'middle'}>{getSymbol(d[currentDrug])}</text>}
+                          {(!isNaN(d[currentDrug]) && key != 'US') && currentState != 'US' && showLabels && 
+                            <text 
+                              x={i == 0 ? specs.xScale(d[specs.xKey]) :  specs.xScale(d[specs.xKey])} 
+                              y={!narrowPoints(xVal) ? (d[currentDrug] == '0.0' ? specs.yScale(d[currentDrug])-22 : specs.yScale(d[currentDrug])-8) : (higherValue(xVal) == currentState ? specs.yScale(d[currentDrug])-16 : specs.yScale(d[currentDrug])+28)}
+                              stroke={''} fill={''} 
+                              strokeWidth={0.25}
+                              fontSize={12} 
+                              textAnchor={i == 0 ? 'right' : 'middle'}>
+                              {showLabels ? d[currentDrug] : ''}
+                            </text>
+                          }
+                          {(!isNaN(d[currentDrug]) && key != 'US' & narrowPoints(xVal)) && currentState != 'US' && showLabels && 
+                            <line
+                              x1={specs.xScale(d[specs.xKey])}
+                              y1={specs.yScale(d[currentDrug])}
+                              x2={specs.xScale(d[specs.xKey])}
+                              y2={higherValue(xVal) == currentState ? specs.yScale(d[currentDrug])-16 : specs.yScale(d[currentDrug]) + 18}
+                              stroke="#666"
+                              strokeWidth={0.7}
+                              strokeDasharray="2,2"
+                              opacity={0.6}
+                          />
+                          }
+                          {(isNaN(d[currentDrug]) && key != 'US') && 
+                          <text x={i == 0 ? specs.xScale(d[specs.xKey]) :  specs.xScale(d[specs.xKey])} y={specs.yScale(0)-8} fontSize={16} textAnchor={'middle'}>{getSymbol(d[currentDrug])}</text>}
+                          {(!isNaN(d[currentDrug]) && key != 'US') && 
+                          <Circle cx={specs.xScale(d[specs.xKey])} cy={Number(d[currentDrug]) == 0 ? (specs.yScale(0)-14) : (specs.yScale(d[currentDrug]))} r={currentTimeframe === 'Monthly' ? 4: 5} fill={currentTimeframe === 'Monthly' && d[specs.xKey] == currentMonth ? 'orange' : UtilityFunctions.getSeriesColorLine(currentDrug, key, false)} />}
+                        </Group>
+                      )
+                    })}
+                    {(!specs.isSmallViewport && yScaleDomainPeriod > 0) &&  (() => {
+                        let yPos = seriesLabelPositionState;
+    
+                        if (currentState != 'US' && key != 'US') {
+                          return (<Group>
+                              <line
+                                id={`line-leading-${currentDrug}`}
+                                x1={specs.xMax + 4}
+                                y1={yPos}
+                                x2={specs.xMax + 25} 
+                                y2={yPos}
+                                stroke={colorScale[currentDrug]}
+                                strokeWidth={0.5}/>
+                              <text
+                                class='adjustCrowded'
+                                x={specs.xMax + 28} 
+                                y={yPos}
+                                alignmentBaseline="middle" 
+                                fontSize={specs.fontSize} 
+                                fill={UtilityFunctions.getSeriesColorLine(currentDrug, key,true)}>
+                                  {drugOptions[currentDrug].titleForDropDown}
+                              </text>
+                            </Group>
+                            )
+                        }
+                      })()
+                    }
+                  </Group>)
+                  }
+                  {
+                    !showPercent && buildToolTipValuesState(sectionWidth, sectionWidthHalf)
+                  }
+                  {
+                    showPercent && 
+                    inp.selectedDrugs.map(drug => {
+                      return buildToolTipValuesPerc(drug)
+                    })
+                  }
+                </Group>
+      </Fragment>
+      )
+  }
+
   return (
     <>
     {accessible ? (
         <>
         <DataTable508
-          data={AccessibilityFunctions.generateLineChartData(data.state, filteredData, currentDataSource, countsDataYearly, countsDataMonthly, currentDrug, selectedDrugs, currentState, stateNames, currentTimeframe, showPercent, showCount, changePrecValues)}
+          data={AccessibilityFunctions.generateLineChartData(filteredData, currentDrug, selectedDrugs, currentState, stateNames, currentTimeframe, showPercent, changePrecValues)}
           labelOverrides={showPercent ? {
             'alldrug': 'All Drugs rate',
             'benzodiazepine': 'Benzodiazepine rate',
@@ -1222,48 +1637,127 @@ function LineChart({ params }) {
         <tr>
           <td style={{width: '85%'}}>
             <svg style={{height: specs.height, width: '100%'}}>
-              <Group top={specs.margin.top} left={specs.margin.left}>
-                {buildLineForDrug(currentDrug)}
-                {inp.selectedDrugs.includes('alldrug') && currentDrug != 'alldrug' && currentState === 'US' && buildLineForDrug('alldrug')}
-                {inp.selectedDrugs.includes('opioid') && currentDrug != 'opioid' && currentState === 'US' && buildLineForDrug('opioid')}
-                {inp.selectedDrugs.includes('heroin') && currentDrug != 'heroin' && currentState === 'US' && buildLineForDrug('heroin')}
-                {inp.selectedDrugs.includes('stimulant') && currentDrug != 'stimulant' && currentState === 'US' && buildLineForDrug('stimulant')}
-                {inp.selectedDrugs.includes('benzodiazepine') && currentDrug != 'benzodiazepine' && currentState === 'US' && buildLineForDrug('benzodiazepine')}
-                {inp.selectedDrugs.includes('fentanyl') && currentDrug != 'fentanyl' && currentState === 'US' && buildLineForDrug('fentanyl')}
-                {inp.selectedDrugs.includes('cocaine') && currentDrug != 'cocaine' && currentState === 'US' && buildLineForDrug('cocaine')}
-                {inp.selectedDrugs.includes('methamphetamine') && currentDrug != 'methamphetamine' && currentState === 'US' && buildLineForDrug('methamphetamine')}
-                
-                <AxisLeft
-                  scale={specs.yScale}
-                  tickLabelProps={() => ({
-                    fontSize: specs.fontSize,
-                    textAnchor: 'end',
-                    dx: -5,
-                    dy: 5
-                  })}
-                />
-                {!specs.isSmallViewport && <text width={specs.yMax} x={specs.margin.left / -2} y={specs.yMax / 2.2} textAnchor="middle" style={{transform: 'rotate(-90deg)', transformOrigin: `-${specs.margin.left / 2}px ${specs.yMax / 2}px`}}>Rate per 100,000 persons<tspan baselineShift="super" fontSize="10">5</tspan></text>}
-                <AxisBottom
-                  top={specs.yMax}
-                  scale={specs.xScale}
-                  tickValues={currentTimeframe === 'Monthly' && specs.isSmallViewport ? lessMonths(filteredData['US'].map(d => d[specs.xKey])) : (isPeriod ? filteredData['US'].map(d => d[specs.xKey]) : filteredData['US'].map(d => d[specs.xKey]))}
-                  tickFormat={value => 
-                      getFormattedValue(value)
-                  }
-                  tickLabelProps={(value) => ({
-                    fontSize: inp['numOfTicks'] > 60 ? specs.fontSize - 4 : specs.fontSize,
-                    textAnchor: (isPeriod ? (inp['numOfTicks'] <= 12 ? 'middle' : 'end') : 'middle'),
-                    angle: (specs.isSmallViewport ? 90 : (isPeriod ? (inp['numOfTicks'] <= 12 ? 0 : -90) : 0)),
-                  })}
-                  labelProps={{
-                    fontSize: specs.fontSize,
-                    textAnchor: 'middle'
-                  }}
-                >
-                </AxisBottom>
-                {(isPeriod && inp['numOfTicks'] > 12) && generateYearLabels()}
-              </Group>
+              {(currentState === 'US' || (currentState !== 'US' && showOverall && !showCompare)) && 
+                <Group top={specs.margin.top} left={specs.margin.left}>
+                  {buildLineForDrug(currentDrug)}
+                  {inp.selectedDrugs.includes('alldrug') && currentDrug != 'alldrug' && currentState === 'US' && buildLineForDrug('alldrug')}
+                  {inp.selectedDrugs.includes('opioid') && currentDrug != 'opioid' && currentState === 'US' && buildLineForDrug('opioid')}
+                  {inp.selectedDrugs.includes('heroin') && currentDrug != 'heroin' && currentState === 'US' && buildLineForDrug('heroin')}
+                  {inp.selectedDrugs.includes('stimulant') && currentDrug != 'stimulant' && currentState === 'US' && buildLineForDrug('stimulant')}
+                  {inp.selectedDrugs.includes('benzodiazepine') && currentDrug != 'benzodiazepine' && currentState === 'US' && buildLineForDrug('benzodiazepine')}
+                  {inp.selectedDrugs.includes('fentanyl') && currentDrug != 'fentanyl' && currentState === 'US' && buildLineForDrug('fentanyl')}
+                  {inp.selectedDrugs.includes('cocaine') && currentDrug != 'cocaine' && currentState === 'US' && buildLineForDrug('cocaine')}
+                  {inp.selectedDrugs.includes('methamphetamine') && currentDrug != 'methamphetamine' && currentState === 'US' && buildLineForDrug('methamphetamine')}
 
+                  <AxisLeft
+                    scale={specs.yScale}
+                    tickLabelProps={() => ({
+                      fontSize: specs.fontSize,
+                      textAnchor: 'end',
+                      dx: -5,
+                      dy: 5
+                    })}
+                  />
+                  {!specs.isSmallViewport && <text width={specs.yMax} x={specs.margin.left / -2} y={specs.yMax / 2.2} textAnchor="middle" style={{transform: 'rotate(-90deg)', transformOrigin: `-${specs.margin.left / 2}px ${specs.yMax / 2}px`}}>Rate per 100,000 persons<tspan baselineShift="super" fontSize="10">5</tspan></text>}
+                  <AxisBottom
+                    top={specs.yMax}
+                    scale={specs.xScale}
+                    tickValues={currentTimeframe === 'Monthly' && specs.isSmallViewport ? lessMonths(filteredData['US'].map(d => d[specs.xKey])) : (isPeriod ? filteredData['US'].map(d => d[specs.xKey]) : filteredData['US'].map(d => d[specs.xKey]))}
+                    tickFormat={value => 
+                        getFormattedValue(value)
+                    }
+                    tickLabelProps={(value) => ({
+                      fontSize: inp['numOfTicks'] > 60 ? specs.fontSize - 4 : specs.fontSize,
+                      textAnchor: (isPeriod ? (inp['numOfTicks'] <= 12 ? 'middle' : 'end') : 'middle'),
+                      angle: (specs.isSmallViewport ? 90 : (isPeriod ? (inp['numOfTicks'] <= 12 ? 0 : -90) : 0)),
+                    })}
+                    labelProps={{
+                      fontSize: specs.fontSize,
+                      textAnchor: 'middle'
+                    }}
+                  >
+                  </AxisBottom>
+                  {(isPeriod && inp['numOfTicks'] > 12) && generateYearLabels()}
+                </Group>
+            }
+            {(currentState !== 'US' && !showOverall && !showCompare) && 
+                <Group top={specs.margin.top} left={specs.margin.left}>
+                  {buildLineForDrugState(currentDrug)}
+                  {inp.selectedDrugs.includes('alldrug') && currentDrug != 'alldrug' && buildLineForDrugState('alldrug')}
+                  {inp.selectedDrugs.includes('opioid') && currentDrug != 'opioid' && buildLineForDrugState('opioid')}
+                  {inp.selectedDrugs.includes('heroin') && currentDrug != 'heroin' && buildLineForDrugState('heroin')}
+                  {inp.selectedDrugs.includes('stimulant') && currentDrug != 'stimulant' && buildLineForDrugState('stimulant')}
+                  {inp.selectedDrugs.includes('benzodiazepine') && currentDrug != 'benzodiazepine' && buildLineForDrugState('benzodiazepine')}
+                  {inp.selectedDrugs.includes('fentanyl') && currentDrug != 'fentanyl' && buildLineForDrugState('fentanyl')}
+                  {inp.selectedDrugs.includes('cocaine') && currentDrug != 'cocaine' && buildLineForDrugState('cocaine')}
+                  {inp.selectedDrugs.includes('methamphetamine') && currentDrug != 'methamphetamine' && buildLineForDrugState('methamphetamine')}
+
+                  <AxisLeft
+                    scale={specs.yScale}
+                    tickLabelProps={() => ({
+                      fontSize: specs.fontSize,
+                      textAnchor: 'end',
+                      dx: -5,
+                      dy: 5
+                    })}
+                  />
+                  {!specs.isSmallViewport && <text width={specs.yMax} x={specs.margin.left / -2} y={specs.yMax / 2.2} textAnchor="middle" style={{transform: 'rotate(-90deg)', transformOrigin: `-${specs.margin.left / 2}px ${specs.yMax / 2}px`}}>Rate per 100,000 persons<tspan baselineShift="super" fontSize="10">5</tspan></text>}
+                  <AxisBottom
+                    top={specs.yMax}
+                    scale={specs.xScale}
+                    tickValues={currentTimeframe === 'Monthly' && specs.isSmallViewport ? lessMonths(filteredData['US'].map(d => d[specs.xKey])) : (isPeriod ? filteredData['US'].map(d => d[specs.xKey]) : filteredData['US'].map(d => d[specs.xKey]))}
+                    tickFormat={value => 
+                        getFormattedValue(value)
+                    }
+                    tickLabelProps={(value) => ({
+                      fontSize: inp['numOfTicks'] > 60 ? specs.fontSize - 4 : specs.fontSize,
+                      textAnchor: (isPeriod ? (inp['numOfTicks'] <= 12 ? 'middle' : 'end') : 'middle'),
+                      angle: (specs.isSmallViewport ? 90 : (isPeriod ? (inp['numOfTicks'] <= 12 ? 0 : -90) : 0)),
+                    })}
+                    labelProps={{
+                      fontSize: specs.fontSize,
+                      textAnchor: 'middle'
+                    }}
+                  >
+                  </AxisBottom>
+                  {(isPeriod && inp['numOfTicks'] > 12) && generateYearLabels()}
+                </Group>
+            }
+            {showCompare && 
+                <Group top={specs.margin.top} left={specs.margin.left}>
+                  {buildLineForDrugStateCompare(currentDrug)}
+
+                  <AxisLeft
+                    scale={specs.yScale}
+                    tickLabelProps={() => ({
+                      fontSize: specs.fontSize,
+                      textAnchor: 'end',
+                      dx: -5,
+                      dy: 5
+                    })}
+                  />
+                  {!specs.isSmallViewport && <text width={specs.yMax} x={specs.margin.left / -2} y={specs.yMax / 2.2} textAnchor="middle" style={{transform: 'rotate(-90deg)', transformOrigin: `-${specs.margin.left / 2}px ${specs.yMax / 2}px`}}>Rate per 100,000 persons<tspan baselineShift="super" fontSize="10">5</tspan></text>}
+                  <AxisBottom
+                    top={specs.yMax}
+                    scale={specs.xScale}
+                    tickValues={currentTimeframe === 'Monthly' && specs.isSmallViewport ? lessMonths(filteredData['US'].map(d => d[specs.xKey])) : (isPeriod ? filteredData['US'].map(d => d[specs.xKey]) : filteredData['US'].map(d => d[specs.xKey]))}
+                    tickFormat={value => 
+                        getFormattedValue(value)
+                    }
+                    tickLabelProps={(value) => ({
+                      fontSize: inp['numOfTicks'] > 60 ? specs.fontSize - 4 : specs.fontSize,
+                      textAnchor: (isPeriod ? (inp['numOfTicks'] <= 12 ? 'middle' : 'end') : 'middle'),
+                      angle: (specs.isSmallViewport ? 90 : (isPeriod ? (inp['numOfTicks'] <= 12 ? 0 : -90) : 0)),
+                    })}
+                    labelProps={{
+                      fontSize: specs.fontSize,
+                      textAnchor: 'middle'
+                    }}
+                  >
+                  </AxisBottom>
+                  {(isPeriod && inp['numOfTicks'] > 12) && generateYearLabels()}
+                </Group>
+            }
             </svg>
           {(currentDrug == 'fentanyl' || selectedDrugs.includes('fentanyl')) &&
           <table style={{width: '100%'}}>

--- a/src/components/LineChart.js
+++ b/src/components/LineChart.js
@@ -268,7 +268,7 @@ function LineChart({ params }) {
   const countsDataYearly = !showCompare ? getCountsYearly(data.sex, currentDataSource, drugOptions) : getCountsYearlyState(data, currentDataSource, currentDrug, compareState);
   const countsDataMonthly = !showCompare ? getCountsMonthly(data.sex, currentDataSource, drugOptions) : getCountsMonthlyState(data, currentDataSource, currentDrug, compareState);
   
-  const yScaleDomainPeriod = (showCompare || showOverall) ? (UtilityFunctions.calculateYScaleDomainCompare(filteredData, currentDrug, currentState, compareState) * 1.2) : (UtilityFunctions.calculateYScaleDomain(filteredData, currentDrug, selectedDrugs, currentState, showOverall) * 1.2);
+  const yScaleDomainPeriod = (showCompare) ? (UtilityFunctions.calculateYScaleDomainCompare(filteredData, currentDrug, currentState, compareState) * 1.2) : (UtilityFunctions.calculateYScaleDomain(filteredData, currentDrug, selectedDrugs, currentState, showOverall) * 1.2);
 
   const currentStaterate = stateNames[currentState];
   const currentStatePctChange = stateNames[currentState] + ' %change in rate';

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1375,6 +1375,91 @@ transition: All 0.3s ease;
 -o-transition: All 0.3s ease;
 }
 
+.toggleD {
+position: relative;
+display: block;
+width: 110px;
+height: 30px;
+padding: 3px;
+margin: auto;
+border-radius: 50px;
+cursor: pointer;
+margin-bottom: 5px!important;
+}
+.toggleD-input {
+position: absolute;
+top: 0;
+left: 0;
+opacity: 0;
+}
+.toggleD-label {
+position: relative;
+display: block;
+height: inherit;
+font-size: 14px;
+background: #607D8B;
+border-radius: inherit;
+box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.12), 
+inset 0 0 3px rgba(0, 0, 0, 0.15);
+}
+.toggleD-label:before, .toggleD-label:after {
+position: absolute;
+top: 50%;
+color: black;
+margin-top: -.5em;
+line-height: 1;
+}
+.toggleD-label:before {
+content: attr(data-off);
+right: 10px;
+color: #fff;
+}
+.toggleD-label:after {
+content: attr(data-on);
+left: 12px;
+color: #fff;
+opacity: 0;
+}
+.toggleD-input:checked~.toggleD-label {
+background: #010679;
+}
+.toggleD-input:checked~.toggleD-label:before {
+opacity: 0;
+}
+.toggleD-input:checked~.toggleD-label:after {
+opacity: 1;
+}
+.toggleD-handle {
+position: absolute;
+top: 4px;
+left: 4px;
+width: 28px;
+height: 28px;
+background: linear-gradient(to bottom, 
+#FFFFFF 40%, #f0f0f0);
+border-radius: 50%;
+}
+.toggleD-handle:before {
+position: absolute;
+top: 50%;
+left: 50%;
+margin: -6px 0 0 -6px;
+width: 16px;
+height: 16px;
+}
+.toggleD-input:checked~.toggleD-handle {
+left: 77.5px;
+box-shadow: -1px 1px 5px 
+rgba(0, 0, 0, 0.2);
+}
+.toggleD-label,
+.toggleD-handle {
+transition: All 0.3s ease;
+-webkit-transition: All 0.3s ease;
+-moz-transition: All 0.3s ease;
+-o-transition: All 0.3s ease;
+}
+
 .select-input
 {
 display: inline-block;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1123,7 +1123,7 @@ transition: All 0.3s ease;
 .toggleA {
 position: relative;
 display: block;
-width: 125px;
+width: 115px;
 height: 30px;
 padding: 3px;
 margin: auto;
@@ -1193,7 +1193,7 @@ width: 16px;
 height: 16px;
 }
 .toggleA-input:checked~.toggleA-handle {
-left: 92.5px;
+left: 82.5px;
 box-shadow: -1px 1px 5px 
 rgba(0, 0, 0, 0.2);
 }
@@ -1293,7 +1293,7 @@ transition: All 0.3s ease;
 .toggleC {
 position: relative;
 display: block;
-width: 125px;
+width: 130px;
 height: 30px;
 padding: 3px;
 margin: auto;
@@ -1363,7 +1363,7 @@ width: 16px;
 height: 16px;
 }
 .toggleC-input:checked~.toggleC-handle {
-left: 92.5px;
+left: 97.5px;
 box-shadow: -1px 1px 5px 
 rgba(0, 0, 0, 0.2);
 }

--- a/src/utility.js
+++ b/src/utility.js
@@ -142,6 +142,30 @@ export const UtilityFunctions = {
       return usmax;
   },
 
+  calculateYScaleDomainCompare: (filteredData, currentDrug, currentState, compareState)=> {
+
+    var compareStateNums = [];
+    var stateNums = [];
+
+    for (var rec in filteredData[compareState])
+      compareStateNums.push(filteredData[compareState][rec][currentDrug])
+
+    for (var rec in filteredData[currentState])
+      stateNums.push(filteredData[currentState][rec][currentDrug])
+    
+    const compareStateNumsFinal = compareStateNums?.filter(i => !isNaN(i));
+    const stateNumsFinal = stateNums?.filter(i => !isNaN(i));
+
+    let compareStatemax = compareStateNumsFinal?.length > 0 ? Math.max(...compareStateNumsFinal) : 0;
+    let statemax = stateNumsFinal?.length > 0 ? Math.max(...stateNumsFinal) : 0;
+
+    if (compareStatemax < statemax)
+      return statemax;
+    else
+      return compareStatemax;
+      
+  },
+  
   calculateMax: (filteredData)=> {
 
     var nums = [];

--- a/src/utility.js
+++ b/src/utility.js
@@ -102,12 +102,37 @@ export const UtilityFunctions = {
         }
   },
 
- calculateYScaleDomain: (filteredData, currentDrug, selectedDrugs, currentState)=> {
+ calculateYScaleDomain: (filteredData, currentDrug, selectedDrugs, currentState, showOverall)=> {
 
     var usNums = [];
     var stateNums = [];
 
-    if (selectedDrugs?.length == 0 || currentState != 'US') {
+    if (currentState == 'US' || (currentState != 'US' && !showOverall)) {
+      if (selectedDrugs?.length == 0) {
+        for (var rec in filteredData["US"])
+          usNums.push(filteredData["US"][rec][currentDrug])
+
+        if (currentState != 'US') {
+          for (var rec in filteredData[currentState])
+            stateNums.push(filteredData[currentState][rec][currentDrug])
+        }
+      }
+      else
+      {
+        for (var idx in selectedDrugs) {
+          for (var rec in filteredData["US"])
+            usNums.push(filteredData["US"][rec][selectedDrugs[idx]])
+        }
+        for (var idx in selectedDrugs) {
+          if (currentState != 'US') {
+            for (var rec in filteredData[currentState])
+              stateNums.push(filteredData[currentState][rec][selectedDrugs[idx]])
+          }
+        }
+      }
+    }
+    else
+    {
       for (var rec in filteredData["US"])
         usNums.push(filteredData["US"][rec][currentDrug])
 
@@ -116,30 +141,33 @@ export const UtilityFunctions = {
           stateNums.push(filteredData[currentState][rec][currentDrug])
       }
     }
-    else
-    {
-      for (var idx in selectedDrugs) {
-        for (var rec in filteredData["US"])
-          usNums.push(filteredData["US"][rec][selectedDrugs[idx]])
+
+      const usNumsFinal = usNums?.filter(i => !isNaN(i));
+      const stateNumsFinal = stateNums?.filter(i => !isNaN(i));
+
+      let usmax = usNumsFinal?.length > 0 ? Math.max(...usNumsFinal) : 0;
+      let statemax = stateNumsFinal?.length > 0 ? Math.max(...stateNumsFinal) : 0;
+
+      if (currentState == 'US') 
+      {
+        if (usmax < statemax)
+          return statemax;
+        else
+          return usmax;
       }
-      for (var idx in selectedDrugs) {
-        if (currentState != 'US') {
-          for (var rec in filteredData[currentState])
-            stateNums.push(filteredData[currentState][rec][selectedDrugs[idx]])
+      else{
+        if (showOverall)
+        {
+          if (usmax < statemax)
+            return statemax;
+          else
+            return usmax;
+        }
+        else
+        {
+            return statemax;
         }
       }
-    }
-
-    const usNumsFinal = usNums?.filter(i => !isNaN(i));
-    const stateNumsFinal = stateNums?.filter(i => !isNaN(i));
-
-    let usmax = usNumsFinal?.length > 0 ? Math.max(...usNumsFinal) : 0;
-    let statemax = stateNumsFinal?.length > 0 ? Math.max(...stateNumsFinal) : 0;
-
-    if (usmax < statemax)
-      return statemax;
-    else
-      return usmax;
   },
 
   calculateYScaleDomainCompare: (filteredData, currentDrug, currentState, compareState)=> {


### PR DESCRIPTION
1. IDEA-D 521: On time trend line graph: when a state is selected, allow visualization of trends for multiple drugs at a time (if the “Overall” (US/participating jurisdictions) toggle is off). The graph currently allows someone to select multiple drugs at a time for the US/overall; would be great to allow it by state too. Note: If “Overall” toggle is on, I think it makes sense to only allow the user to compare the US vs. a state for a single drug at a time, as is done currently.
2. IDEA-D 522: On time trend line graph: allow user to select multiple states at a time (only available when user selects 1 drug at a time). I.e., instead of only allowing user to compare a state to “US/overall,” also allow them to compare 2 states to each other.
3. IDEA-D 532: On the accessible page please change in the row 2024-foot note symbol from † to § footnote. Please see screenshot for clarity.
 
Thanks.
