### PR TITLE
UAT changes requested

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -568,7 +568,7 @@ export default function App(params) {
                 <table style={{ width: '100%', tableLayout: 'fixed' }}>
                   <tr>
                     <td style={{ width: '50%', verticalAlign: 'top', textAlign: showCompare ? 'right' : 'left' }}>
-                       {!showOverall && !showCompare && <label className="subLabel">Make a selection to change the line graph&nbsp;&nbsp;</label>}
+                       {!showOverall && !showCompare && <label className="subLabel">Make a selection to change the {accessible ? 'table' : 'line graph'}&nbsp;&nbsp;</label>}
                        {showCompare && <label className="subLabel">Select a jurisdiction to compare:&nbsp;&nbsp;</label>}
                     </td>
                     <td style={{ width: '18%', verticalAlign: 'top' }}>
@@ -763,7 +763,7 @@ export default function App(params) {
           <table style={{ tableLayout: 'fixed', display: 'block', width: '100%' }}>
           <tr>
             <td colSpan='2'>
-                  {!showOverall && !showCompare && <label className="subLabel">Make a selection to change the line graph&nbsp;&nbsp;</label>}
+                  {!showOverall && !showCompare && <label className="subLabel">Make a selection to change the {accessible ? 'table' : 'line graph'}&nbsp;&nbsp;</label>}
                   {showCompare && <label className="subLabel">Select a jurisdiction to compare:&nbsp;&nbsp;</label>}
             </td>
           </tr>
@@ -1241,7 +1241,7 @@ export default function App(params) {
           <tr style={{ textAlign: 'left', fontSize: '15px' }}><td>{'† Data not available/not reported'}<sup>4</sup></td></tr>
           {(chart == 'Line' || chart == 'Sex') && <tr style={{ textAlign: 'left', fontSize: '15px' }}><td>{'§ Overall monthly and annual counts from 2024 (i.e., 2024 data for all participating jurisdictions combined) will be suppressed until all jurisdictions on the DOSE-DIS dashboard have submitted data.'}</td></tr>}
           {/* SKV TODO what should be the symbol for rate below*/}
-          {addl && showPercent && <tr style={{ textAlign: 'left', fontSize: '15px' }}><td>{'§ Rate per 100,000 persons'}<sup>5</sup></td></tr>}
+          {addl && showPercent && !accessible && <tr style={{ textAlign: 'left', fontSize: '15px' }}><td>{'§ Rate per 100,000 persons'}<sup>5</sup></td></tr>}
         </table>
       </div>
     )

--- a/src/components/ChangeIndicator.js
+++ b/src/components/ChangeIndicator.js
@@ -38,7 +38,7 @@ function ChangeIndicator(params) {
                         (percentValue == 0 ? [] : decreaseArrayPoints.map(p => [p.x, p.y]))}
                     fill={colorScale[defaultValueIfEmpty(label, defaultLabelIfEmpty)]}
                 ></Polygon>
-                <text x={percentValue == 0 ? width/2 + 5 : width/2} y={percentValue > 0 ? height/2 + 5: height/2} textAnchor="middle" fontSize={percentValue == 0 ? 16 : 9.5}
+                <text x={percentValue == 0 ? width/2 + 5 : width/2} y={percentValue > 0 ? height/2 + 5: height/2} textAnchor="middle" fontSize={percentValue == 0 ? 16 : 12}
                     stroke={percentValue == 0 ? colorScale[defaultValueIfEmpty(label, defaultLabelIfEmpty)] :'#fff'} fontWeight="normal"
                 >
                     {Math.abs(percentValue).toFixed(1)}%

--- a/src/components/LineChart.js
+++ b/src/components/LineChart.js
@@ -271,7 +271,7 @@ function LineChart({ params }) {
   const yScaleDomainPeriod = (showCompare) ? (UtilityFunctions.calculateYScaleDomainCompare(filteredData, currentDrug, currentState, compareState) * 1.2) : (UtilityFunctions.calculateYScaleDomain(filteredData, currentDrug, selectedDrugs, currentState, showOverall) * 1.2);
 
   const currentStaterate = stateNames[currentState];
-  const currentStatePctChange = stateNames[currentState] + ' %change in rate';
+  const currentStatePctChange = stateNames[currentState] + ' % change in rate';
   const currentStateCnt = stateNames[currentState];
 
   useEffect(() => {
@@ -1687,15 +1687,15 @@ function LineChart({ params }) {
             'stimulant': 'All Stimulants rate',
             'fentanyl': 'Fentanyl rate',
             'Overall': !showCompare ? 'Overall rate' : stateNames[compareState] + ' rate',
-            'alldrug_pct': 'All Drugs %change in rate',
-            'benzodiazepine_pct': 'Benzodiazepine %change in rate',
-            'cocaine_pct': 'Cocaine %change in rate',
-            'heroin_pct': 'Heroin %change in rate',
-            'methamphetamine_pct': 'Methamphetamine %change in rate',
-            'opioid_pct': 'All Opioids %change in rate',
-            'stimulant_pct': 'All Stimulants %change in rate',
-            'fentanyl_pct': 'Fentanyl %change in rate',
-            'Overall_pct': (!showCompare ? 'Overall' : stateNames[compareState]) + ' %change in rate',
+            'alldrug_pct': 'All Drugs % change in rate',
+            'benzodiazepine_pct': 'Benzodiazepine % change in rate',
+            'cocaine_pct': 'Cocaine % change in rate',
+            'heroin_pct': 'Heroin % change in rate',
+            'methamphetamine_pct': 'Methamphetamine % change in rate',
+            'opioid_pct': 'All Opioids % change in rate',
+            'stimulant_pct': 'All Stimulants % change in rate',
+            'fentanyl_pct': 'Fentanyl % change in rate',
+            'Overall_pct': (!showCompare ? 'Overall' : stateNames[compareState]) + ' % change in rate',
             'state' : currentStaterate,
             'state_pct' : currentStatePctChange,
             'Year/Month': currentTimeframe == 'Monthly' ? 'Month and Year' : 'Year',
@@ -1741,7 +1741,7 @@ function LineChart({ params }) {
           colSpan={getColSpan()}
           colSpan2={getColSpan2()}
           isSmallViewport={specs['isSmallViewport']}
-          supScript={showPercent ?'§': ''}
+          supScript={showPercent ?'': ''}
           noSort={true}
         />
         {(currentDrug == 'fentanyl' || selectedDrugs.includes('fentanyl')) &&

--- a/src/components/quickStat.js
+++ b/src/components/quickStat.js
@@ -9,8 +9,8 @@ function QuickStat(params) {
                         <div className="stats-section first">
                           <div id="stats-section-icon" className="" >
                             <ChangeIndicator
-                              width={85}
-                              height={80}
+                              width={95}
+                              height={90}
                               colorScale={colorScale}
                               defaultValueIfEmpty={defaultValueIfEmpty}
                               percentValue={value}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1509,7 +1509,7 @@ align-items: center;
 .stats-section-icon
 {
 /* height: calc(100px - 1em - 2px); */
-width: 30%;
+width: 35%;
 height: 100%;
 display: inline-block;
 vertical-align: top;
@@ -1517,7 +1517,7 @@ margin-top: 10px;
 }
 
 .stats-section .stats-text {
-width: 70%;
+width: 65%;
 display: inline-block;
 padding: 0.25em;
 font-size: 14px;


### PR DESCRIPTION
1. When hoovering over the compare off toggle button within the Trends line graph, please make the change to the tooltip to say, "Toggle to compare the selected jurisdictions".
2. Please remove the extraneous footnote in the accessibility section. 
3. Grammar correction in accessibility section: %change vs. % change [i.e., need a space between the word "%" and the word "change". 
4. Word change in accessibility section: need to change the words "line graph" to "Table". 
5. Font change in accessibility section: the % change value is hard to see (see screenshot). Can the numbers and % symbol inside the arrow be a larger font size?

Thanks.