### PR TITLE
Findings from UAT.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1563,8 +1563,8 @@ export default function App(params) {
                     ))}
                   </div>
                   <div className="tab-content">
-                    {activeTab == 0 && <span><strong>ED Visits:</strong> Discharge data that captures information about patients who sought care at Emergency Department (ED) and were discharged from the ED.</span>}
-                    {activeTab == 1 && <span><strong>Inpatient Hospitalization:</strong> These discharge data refer to information collected about patients’ hospital stays. Inpatient hospitalizations may represent increased severity of nonfatal overdoses, as compared to ED visits.</span>}
+                    {activeTab == 0 && <span><strong>ED Visits:</strong> Discharge data that capture information about patients who sought care at an Emergency Department (ED) and were discharged from the ED.</span>}
+                    {activeTab == 1 && <span><strong>Inpatient Hospitalizations:</strong> These discharge data refer to information collected about patients’ hospital stays. Inpatient hospitalizations may represent increased severity of nonfatal overdoses, as compared to ED visits.</span>}
                   </div>
                 </div>
               </div>

--- a/src/accessibility.js
+++ b/src/accessibility.js
@@ -86,7 +86,7 @@ export const AccessibilityFunctions = {
               perc = ((diff / rec.valPrev) * 100)
           }
     
-          return perc.toFixed(2);
+          return !isNaN(perc) ? perc.toFixed(1) : '';
         }
         return '';
     },

--- a/src/components/ChangeIndicator.js
+++ b/src/components/ChangeIndicator.js
@@ -38,7 +38,7 @@ function ChangeIndicator(params) {
                         (percentValue == 0 ? [] : decreaseArrayPoints.map(p => [p.x, p.y]))}
                     fill={colorScale[defaultValueIfEmpty(label, defaultLabelIfEmpty)]}
                 ></Polygon>
-                <text x={percentValue == 0 ? width/2 + 5 : width/2} y={percentValue > 0 ? height/2 + 5: height/2} textAnchor="middle" fontSize={percentValue == 0 ? 16 : 12}
+                <text x={percentValue == 0 ? width/2 + 5 : width/2} y={percentValue > 0 ? height/2 + 5: height/2} textAnchor="middle" fontSize={percentValue == 0 ? 16 : 13}
                     stroke={percentValue == 0 ? colorScale[defaultValueIfEmpty(label, defaultLabelIfEmpty)] :'#fff'} fontWeight="normal"
                 >
                     {Math.abs(percentValue).toFixed(1)}%

--- a/src/components/LineChart.js
+++ b/src/components/LineChart.js
@@ -779,7 +779,7 @@ function LineChart({ params }) {
     if (rec != null && !isNaN(rec.valPrev)) {
       if (rec.value != rec.valPrev) {
           diff =  rec.value - rec.valPrev;
-          perc = ((diff / rec.valPrev) * 100)
+          perc = ((diff / rec.valPrev) * 100);
       }
 
       tooltipHtml = ReactDOMServer.renderToString(buildPercentChartInd(rec.drug, rec.yr, perc, stateNames[rec.state], rec.yearmon))

--- a/src/components/quickStat.js
+++ b/src/components/quickStat.js
@@ -9,8 +9,8 @@ function QuickStat(params) {
                         <div className="stats-section first">
                           <div id="stats-section-icon" className="" >
                             <ChangeIndicator
-                              width={95}
-                              height={90}
+                              width={100}
+                              height={95}
                               colorScale={colorScale}
                               defaultValueIfEmpty={defaultValueIfEmpty}
                               percentValue={value}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1509,7 +1509,7 @@ align-items: center;
 .stats-section-icon
 {
 /* height: calc(100px - 1em - 2px); */
-width: 35%;
+width: 38%;
 height: 100%;
 display: inline-block;
 vertical-align: top;
@@ -1517,7 +1517,7 @@ margin-top: 10px;
 }
 
 .stats-section .stats-text {
-width: 65%;
+width: 62%;
 display: inline-block;
 padding: 0.25em;
 font-size: 14px;


### PR DESCRIPTION
1. For both DIS Accessibility AND Interactive views: minor grammatical fixes at top of dashboard.
2. DIS Accessibility view only: The first table says "NaN" below for cocaine % change in rate, when the rate is * (suppressed). It should be blank, not "NaN." This seems to be maybe only a problem for cocaine (The screenshot below is from when I selected Iowa ED data)

Thanks.