### PR TITLE
Sravan dose surveillance 02122026 0800

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1242,6 +1242,12 @@ const getYears = (startYrInp, endYrInp) => {
       )
   }
 
+  const isEthnGrayBox = () => {
+    return (UtilityFunctions.isCovidPeriod(currentYearSexAge + String(currentMonthSexAge).padStart(2, '0')) || Number(currentYearSexAge) < 2023);
+  }
+
+  (UtilityFunctions.isCovidPeriod(currentYearSexAge + String(currentMonthSexAge).padStart(2, '0')) || Number(currentYearSexAge) < 2023)
+
   const stateBarChartMemo = useMemo(() =>
     <>
    <div id="state-chart-container" className="chart-container" ref={stateBarChartRef}>
@@ -1353,7 +1359,7 @@ const getYears = (startYrInp, endYrInp) => {
     <div className="column column-right">
         <div className={!accessible ? "subsection marked " : " " + (!accessible ? (selectedDrugsSexAge[0] + 'ToolTip') : '')}>
           {!accessible && <span className="individual-header margin-top">By Sex ({jurisCountData[currentYearSexAge + String(currentMonthSexAge).padStart(2, '0') + sexAgeMonthly]} Jurisdictions)</span>}
-          <div class={currentState === 'US' ? "chartDivAll" : "chartDivAll"} ref={sexChartRef}>
+          <div class={currentState === 'US' ? "chartDivAllDem" : "chartDivAllDem"} ref={sexChartRef}>
             <SexChart
                 data={sexAgeMonthly == 'Annual' ? keyedRawUSDataAnnual :  keyedRawUSDataMonthly}
                 year={'2023'}
@@ -1380,7 +1386,7 @@ const getYears = (startYrInp, endYrInp) => {
     <div className="column column-right">
         <div className={!accessible ? "subsection marked " : " " + (!accessible ? (selectedDrugsSexAge[0] + 'ToolTip') : '')}>
           {!accessible && <span className="individual-header margin-top">By Age (In years) ({jurisCountData[currentYearSexAge + String(currentMonthSexAge).padStart(2, '0') + sexAgeMonthly]} Jurisdictions)</span>}
-          <div class={currentState === 'US' ? "chartDivAll" : "chartDivAll"} ref={ageChartRef}>
+          <div class={currentState === 'US' ? "chartDivAllDem" : "chartDivAllDem"} ref={ageChartRef}>
             <AgeChart
                 data={sexAgeMonthly == 'Annual' ? keyedRawUSDataAnnual :  keyedRawUSDataMonthly}
                 maxes={{'month': 6150,'quarter': 17726}}
@@ -1410,7 +1416,7 @@ const getYears = (startYrInp, endYrInp) => {
     <div className={"column column-right"}>
         <div className={!accessible ? "subsection marked " : " " + (!accessible ? (selectedDrugsSexAge[0] + 'ToolTip') : '')}>
           {!accessible && <span className="individual-header margin-top">By Age (In years) and Sex ({jurisCountData[currentYearSexAge + String(currentMonthSexAge).padStart(2, '0') + sexAgeMonthly]} Jurisdictions)</span>}
-          <div class='' ref={sexAgeChartRef}>
+          <div class='chartDivAllDem' ref={sexAgeChartRef}>
             <SexAgeChart 
             data={sexAgeMonthly == 'Annual' ? keyedRawUSDataAnnual :  keyedRawUSDataMonthly}
             currentTimeframe={sexAgeMonthly}
@@ -1423,6 +1429,7 @@ const getYears = (startYrInp, endYrInp) => {
             currentDataType={currentDataType}
             accessible={accessible}
             widthReduction={(!isSmallViewport && !accessible) ? true : false}
+            isEthnGrayBox={isEthnGrayBox()}
             />
           </div>
         </div>
@@ -1434,8 +1441,8 @@ const getYears = (startYrInp, endYrInp) => {
     <>
    <div className={"column column-right"}>
         <div className={!accessible ? "subsection marked " : " " + (!accessible ? (selectedDrugsSexAge[0] + 'ToolTip') : '')}>
-          {!accessible && <span className="individual-header margin-top">By Race/Ethnicity {Number(currentYearSexAge) > 2022 && jurisEthnCountData[currentYearSexAge + String(currentMonthSexAge).padStart(2, '0') + sexAgeMonthly] != null ? '(' + jurisEthnCountData[currentYearSexAge + String(currentMonthSexAge).padStart(2, '0') + sexAgeMonthly] + ' Jurisdictions)' : ' (0 Jurisdictions)'}{(UtilityFunctions.isCovidPeriod(currentYearSexAge + String(currentMonthSexAge).padStart(2, '0')) || Number(currentYearSexAge) < 2023) ? null : <sup>§</sup>}</span>}
-          <div class='' ref={sexAgeChartRef}>
+          {!accessible && <span className="individual-header margin-top">By Race/Ethnicity {Number(currentYearSexAge) > 2022 && jurisEthnCountData[currentYearSexAge + String(currentMonthSexAge).padStart(2, '0') + sexAgeMonthly] != null ? '(' + jurisEthnCountData[currentYearSexAge + String(currentMonthSexAge).padStart(2, '0') + sexAgeMonthly] + ' Jurisdictions)' : ' (0 Jurisdictions)'}{isEthnGrayBox() ? null : <sup>§</sup>}</span>}
+          <div class='chartDivAllDem' ref={ethnicityChartRef}>
             <EthnicityChart 
             data={ethnicityData}
             currentTimeframe={sexAgeMonthly}
@@ -1448,6 +1455,7 @@ const getYears = (startYrInp, endYrInp) => {
             currentDataType={currentDataType}
             accessible={accessible}
             widthReduction={(!isSmallViewport && !accessible) ? true : false}
+            isEthnGrayBox={isEthnGrayBox()}
             />
           </div>
         </div>
@@ -3680,6 +3688,7 @@ const getYears = (startYrInp, endYrInp) => {
                 <li><strong>Drug overdose visit numbers are not mutually exclusive</strong> but rather reflect nesting of drug categories and some drug overdose visits involved multiple substances (e.g., a given drug overdose ED visit could have involved both opioids and stimulants).</li>
                 <li>DOSE-SYS data could be suppressed for a variety of reasons. For example, rates based on 1-19 overdose counts are suppressed to avoid sharing information that could be identifiable and because of possible instability of rate estimates. For more information, please see <a target="_blank" href="https://www.cdc.gov/nchs/data/statnt/statnt24.pdf">Healthy People 2010 Criteria for Data Suppression</a>.  Additionally, data are shown for the time period beginning January 2019 and exclude several months during the onset of the COVID-19 pandemic (i.e., March 2020-August 2020) for all jurisdictions. Other situations when data coverage was incomplete may also lead to data suppression.</li>
                 <li>This dashboard shows ED visits for suspected nonfatal drug overdoses of unintentional or undetermined intent. For full definitions, query syntax, and technical briefs, see: <a target="_blank" href="https://knowledgerepository.syndromicsurveillance.org/search/syndrome?keys=overdose%20od2a%202.0&sort_by=field_submitting_author_organiza&sort_order=DESC&f%5B0%5D=submitting_author_organization%3ACDC&page=1">Knowledge Repository</a>.</li>
+                <li>The DOSE-SYS dashboard presents combined race and ethnicity data from 2023 onward. Data for 2018-2022 are excluded due to significant missingness (47% in 2018 among participating jurisdictions, decreasing to &lt;10% in 2023). Jurisdictions with 15% or greater missingness and observations with unknown race/ethnicity during the selected period are not included in the figures. Reported race and ethnicity data may originate from patient self-reports, representatives, or clinical providers.</li>
               </ol>
             </div>}
         </div>

--- a/src/App.js
+++ b/src/App.js
@@ -1246,8 +1246,6 @@ const getYears = (startYrInp, endYrInp) => {
     return (UtilityFunctions.isCovidPeriod(currentYearSexAge + String(currentMonthSexAge).padStart(2, '0')) || Number(currentYearSexAge) < 2023);
   }
 
-  (UtilityFunctions.isCovidPeriod(currentYearSexAge + String(currentMonthSexAge).padStart(2, '0')) || Number(currentYearSexAge) < 2023)
-
   const stateBarChartMemo = useMemo(() =>
     <>
    <div id="state-chart-container" className="chart-container" ref={stateBarChartRef}>

--- a/src/App.js
+++ b/src/App.js
@@ -3576,6 +3576,7 @@ const getYears = (startYrInp, endYrInp) => {
                   {ageChartMemo}
                 </td>
               </tr>
+              <br></br>
               <tr>
                 <td style={{width: '50%'}}>
                   {sexAgeChartMemo}

--- a/src/App.js
+++ b/src/App.js
@@ -1359,7 +1359,7 @@ const getYears = (startYrInp, endYrInp) => {
     <div className="column column-right">
         <div className={!accessible ? "subsection marked " : " " + (!accessible ? (selectedDrugsSexAge[0] + 'ToolTip') : '')}>
           {!accessible && <span className="individual-header margin-top">By Sex ({jurisCountData[currentYearSexAge + String(currentMonthSexAge).padStart(2, '0') + sexAgeMonthly]} Jurisdictions)</span>}
-          <div class={currentState === 'US' ? "chartDivAllDem" : "chartDivAllDem"} ref={sexChartRef}>
+          <div className="chartDivAllDem" ref={sexChartRef}>
             <SexChart
                 data={sexAgeMonthly == 'Annual' ? keyedRawUSDataAnnual :  keyedRawUSDataMonthly}
                 year={'2023'}

--- a/src/components/EthnicityChart.js
+++ b/src/components/EthnicityChart.js
@@ -418,7 +418,7 @@ const getEthnGroupsDummy = (data) => {
 
 function EthnicityChart(params) {
 
-  const { data, currentTimeframe, currentDrug, currentYear, currentMonth, currentDataType, width, height, drugOptions, accessible, widthReduction, isEthnGrayBox } = params;
+  const { data, currentTimeframe, currentDrug, currentYear, currentMonth, currentDataType, width, height, drugOptions, accessible, widthReduction } = params;
 
   const ethnGroupsReal = getEthnGroups(data, currentTimeframe, currentYear, currentMonth)
   const filteredDataReal = getFilteredData(data, ethnGroupsReal, currentDrug, currentTimeframe, currentYear, currentMonth, currentDataType);

--- a/src/components/EthnicityChart.js
+++ b/src/components/EthnicityChart.js
@@ -418,7 +418,7 @@ const getEthnGroupsDummy = (data) => {
 
 function EthnicityChart(params) {
 
-  const { data, currentTimeframe, currentDrug, currentYear, currentMonth, currentDataType, width, height, drugOptions, accessible, widthReduction } = params;
+  const { data, currentTimeframe, currentDrug, currentYear, currentMonth, currentDataType, width, height, drugOptions, accessible, widthReduction, isEthnGrayBox } = params;
 
   const ethnGroupsReal = getEthnGroups(data, currentTimeframe, currentYear, currentMonth)
   const filteredDataReal = getFilteredData(data, ethnGroupsReal, currentDrug, currentTimeframe, currentYear, currentMonth, currentDataType);

--- a/src/components/EthnicityChart.js
+++ b/src/components/EthnicityChart.js
@@ -434,7 +434,7 @@ function EthnicityChart(params) {
 
   const isSmallViewport = width < 550 && !widthReduction;
   const fontSize = 16;
-  const margin = { top: 50, bottom: 145, left: isSmallViewport ? 200 : 180, right: isSmallViewport ? 0 : 15 };
+  const margin = { top: 15, bottom: 145, left: isSmallViewport ? 200 : 180, right: isSmallViewport ? 0 : 15 };
 
   const xMax = width - margin.left - margin.right;
   const yMax = height - margin.top - margin.bottom - (isSmallViewport ? 10 : 0);

--- a/src/components/SexAgeChart.js
+++ b/src/components/SexAgeChart.js
@@ -294,7 +294,7 @@ function SexAgeChart(params) {
 
   const isSmallViewport = width < 550 && !widthReduction;
   const fontSize = 16;
-  const margin = { top: 50, bottom: 145, left: 50, right: 15 };
+  const margin = { top: 15, bottom: 145, left: 50, right: 15 };
 
   const xMax = width - margin.left - margin.right;
   const xMaxHalf = xMax / 2;

--- a/src/components/SexAgeChart.js
+++ b/src/components/SexAgeChart.js
@@ -286,7 +286,7 @@ const getAgeGroups = (data, currentTimeLine, currentYear, currentMonth) => {
 
 function SexAgeChart(params) {
 
-  const { data, currentTimeframe, currentDrug, currentYear, currentMonth, currentDataType, width, height, drugOptions, accessible, widthReduction } = params;
+  const { data, currentTimeframe, currentDrug, currentYear, currentMonth, currentDataType, width, height, drugOptions, accessible, widthReduction, isEthnGrayBox } = params;
 
   const ageGroups = getAgeGroups(data, currentTimeframe, currentYear, currentMonth)
   const filteredData = getFilteredData(data, ageGroups, currentDrug, currentTimeframe, currentYear, currentMonth, currentDataType);
@@ -470,7 +470,7 @@ function SexAgeChart(params) {
         }
         </>        
       ) : (
-      <svg style={{ height: height + (!isSmallViewport ? 140 : 10) }}>
+      <svg style={{ height: height + (!isSmallViewport ? (isEthnGrayBox ? 10: 140) : 10) }}>
         <Group top={margin.top} left={margin.left}>
           <Text x={x1Scale(0) - 15} y={0} fill={'#000066'} textAnchor="end">Female</Text>
           <Text x={x2Scale(0) + 15} y={0} fill={'#000066'} >Male</Text>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1713,6 +1713,11 @@ width: 90%;
 width: 100%;
 }
 
+.chartDivAllDem {
+width: 100%;
+padding-top: 40px;
+}
+
 .drugsDivTop {
 padding-bottom: 8px!important;
 }

--- a/src/utility.js
+++ b/src/utility.js
@@ -765,8 +765,7 @@ export const UtilityFunctions = {
     return (
       <Fragment>
         <>
-        <br></br><br></br>
-        <div style={{ height: hgt + 40, width: wid, textAlign: 'left', verticalAlign: 'middle', backgroundColor: 'lightgray', fontWeight: 'bold', borderRadius: '15px'}}><p style={{ textAlign: 'left', fontWeight: 'bold', padding: '20px'}}>Grayed out figure represents the COVID-19 pademic and is distinct from data suppression for other reasons.</p></div>
+        <div style={{ height: hgt - 100, width: wid, textAlign: 'left', display: 'flex', alignItems: 'center', backgroundColor: '#E7E7E7', fontWeight: 'bold', borderRadius: '30px'}}><p style={{ textAlign: 'left', fontWeight: 'bold', padding: '20px'}}>Grayed out figure represents the COVID-19 pademic and is distinct from data suppression for other reasons.</p></div>
         </>
         </Fragment>
         )
@@ -776,11 +775,11 @@ export const UtilityFunctions = {
     return (
       <Fragment>
         <>
-        <br></br><br></br>
-        <div style={{ height: hgt + 40, width: wid, textAlign: 'left', verticalAlign: 'middle', backgroundColor: 'lightgray', fontWeight: 'bold', borderRadius: '15px'}}><p style={{ textAlign: 'left', fontWeight: 'bold', padding: '20px'}}>Grayed out figure represents time periods where race/ethnicity data missingness is greater than 10% and is distinct from data suppression for other reasons.</p></div>
+        <div style={{ height: hgt, width: wid, textAlign: 'left', display: 'flex', alignItems: 'center', backgroundColor: '#E7E7E7', fontWeight: 'bold', borderRadius: '30px'}}><p style={{ textAlign: 'left', fontWeight: 'bold', padding: '20px'}}>Grayed out figure represents time periods where race/ethnicity data missingness is greater than 10% and is distinct from data suppression for other reasons.</p></div>
         </>
         </Fragment>
         )
+       
   },
 
 }

--- a/src/utility.js
+++ b/src/utility.js
@@ -765,7 +765,7 @@ export const UtilityFunctions = {
     return (
       <Fragment>
         <>
-        <div style={{ height: hgt - 100, width: wid, textAlign: 'left', display: 'flex', alignItems: 'center', backgroundColor: '#E7E7E7', fontWeight: 'bold', borderRadius: '30px'}}><p style={{ textAlign: 'left', fontWeight: 'bold', padding: '20px'}}>Grayed out figure represents the COVID-19 pademic and is distinct from data suppression for other reasons.</p></div>
+        <div style={{ height: hgt - 100, width: wid, textAlign: 'left', display: 'flex', alignItems: 'center', backgroundColor: '#E7E7E7', fontWeight: 'bold', borderRadius: '30px'}}><p style={{ textAlign: 'left', fontWeight: 'bold', padding: '20px'}}>Grayed out figure represents the COVID-19 pandemic and is distinct from data suppression for other reasons.</p></div>
         </>
         </Fragment>
         )


### PR DESCRIPTION
Business Requirements:
IDEA-S 22: DOSE-SYS dashboard R/E figure will look like for time periods before 2023 for DOSE-SYS (bottom right quadrant; please use the text in the figure.
IDEA-S 23: Align the format for the covid-19 time period, please put a gray box there for both ranked bar chart figures, plus the demographic figures, with the following text
Add "Important Data Consideration" as number 12 (the last consideration in the list)

QA/UAT Findings:
The %ages in the "Note" below the SYS R/E figure are inaccurate (they seemed much too high). I checked with Sagar and he noted you all were pulling from the wrong column. You all "used the drug_rate from column G for that data point and need to use drug_pct from column H.
In SexAge chart, the bar graphs are not equal in length for Male and Female, when the corresponding values are equal, in some scenarios.
When the gray box is displayed Race Ethnicity, the two graphs (age and Race) are misaligned and should be displayed side by side.
Move the anchors up that are for By Sex and By Age.  They should not coincide with the graph but be above it.

Thanks.
