### PR TITLE
QA findings and New Business Requirements

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1259,7 +1259,7 @@ const getYears = (startYrInp, endYrInp) => {
   }
 
   const isEthnGrayBox = () => {
-    return (UtilityFunctions.isCovidPeriodGrayBox(sexAgeMonthly, currentYearSexAge, currentMonthSexAge) || Number(currentYearSexAge) < 2023);
+    return (UtilityFunctions.isCovidPeriodGrayBox(sexAgeMonthly, currentYearSexAge, currentMonthSexAge) || Number(currentYearSexAge) < 2023) || (Number(currentYearSexAge) == 2023 && Number(currentMonthSexAge) < 12 && sexAgeMonthly == 'Annual');
   }
 
   const stateBarChartMemo = useMemo(() =>

--- a/src/components/EthnicityChart.js
+++ b/src/components/EthnicityChart.js
@@ -557,7 +557,12 @@ function EthnicityChart(params) {
     if (UtilityFunctions.isCovidPeriodGrayBox(currentTimeframe, currentYear, currentMonth))
         return UtilityFunctions.getCovidGrayBox(height, width);
     else 
-      return UtilityFunctions.getNoDataGrayBoxForEthn(height + 40, width);
+      return UtilityFunctions.getNoDataGrayBoxForEthn(height + (currentDataType == 'percent' ? 80 : 40), width);
+  }
+
+  if (Number(currentYear) == 2023 && Number(currentMonth) < 12 && currentTimeframe == 'Annual' && !accessible)
+  {
+      return UtilityFunctions.getAnnualNoDataGrayBoxForEthn(height + (currentDataType == 'percent' ? 80 : 40), width);
   }
 
   return (

--- a/src/components/SexAgeChart.js
+++ b/src/components/SexAgeChart.js
@@ -501,7 +501,7 @@ function SexAgeChart(params) {
         <AxisBottom
             top={yMax}
             scale={x1Scale}
-            numTicks={isSmallViewport ? 3 : 6}
+            numTicks={3}
             tickStroke="none"
             tickFormat={value => 
                       getFormattedValue(value)
@@ -509,7 +509,7 @@ function SexAgeChart(params) {
             tickLabelProps={(value) => {
               return {
                 style: {
-                  transform: (isSmallViewport && currentDataType == 'percent' ? 'rotate(-60deg)' : ''),
+                  transform: (isSmallViewport ? 'rotate(-60deg)' : ''),
                   transformOrigin: `${x1Scale(value)}px ${18}px`,
                   textAnchor: 'middle',
                   fontSize: fontSize,
@@ -521,7 +521,7 @@ function SexAgeChart(params) {
           <AxisBottom
             top={yMax}
             scale={x2Scale}
-            numTicks={isSmallViewport ? 3 : 6}
+            numTicks={3}
             tickStroke="none"
             tickFormat={value => 
                       getFormattedValue(value)
@@ -529,7 +529,7 @@ function SexAgeChart(params) {
             tickLabelProps={(value) => {
               return {
                 style: {
-                  transform: (isSmallViewport && currentDataType == 'percent' ? 'rotate(-60deg)' : ''),
+                  transform: (isSmallViewport ? 'rotate(-60deg)' : ''),
                   transformOrigin: `${x2Scale(value)}px ${18}px`,
                   textAnchor: 'middle',
                   fontSize: fontSize,
@@ -542,7 +542,7 @@ function SexAgeChart(params) {
           {<text x={!isSmallViewport ? xMax/2 : 80} y={yMax+ 90} fill={'#000066'} fontSize={fontSize * (isSmallViewport ? .8 : 1)} textAnchor="middle">{(currentDataType == 'rate' ?  '' : 'Involving ') + drugOptions[currentDrug].titleAll + (currentDataType == 'rate' ?  ' per 10,000 Total ED visits' : '')}</text>}
         </Group>
       </svg>
-      <div style={{height: (isEthnGrayBox ? (isSmallViewport ? (currentDataType == 'rate' ? '160px' : '210px') : '100px') : (isSmallViewport ? (currentDataType == 'rate' ? '160px' : '210px') : '300px'))}}>
+      <div style={{height: (isEthnGrayBox ? (isSmallViewport ? (currentDataType == 'rate' ? '160px' : '210px') : (currentDataType == 'rate' ? '100px' : '140px')) : (isSmallViewport ? (currentDataType == 'rate' ? '160px' : '210px') : '300px'))}}>
         <table>
           {!UtilityFunctions.allDataIsSupressedSA(filteredData) &&
             <tr><td><small><i>{getMissingNote(missingData)}</i></small></td></tr>

--- a/src/utility.js
+++ b/src/utility.js
@@ -814,7 +814,18 @@ export const UtilityFunctions = {
     return (
       <Fragment>
         <>
-        <div style={{ height: hgt + 40, width: wid, textAlign: 'left', display: 'flex', alignItems: 'center', backgroundColor: '#E7E7E7', fontWeight: 'bold', borderRadius: '30px'}}><p style={{ textAlign: 'left', fontWeight: 'bold', padding: '20px'}}>Grayed out figure represents time periods where race/ethnicity data missingness is greater than 10% and is distinct from data suppression for other reasons.</p></div>
+        <div style={{ height: hgt + 40, width: wid, textAlign: 'left', display: 'flex', alignItems: 'center', backgroundColor: '#E7E7E7', fontWeight: 'bold', borderRadius: '30px'}}><p style={{ textAlign: 'left', fontWeight: 'bold', padding: '20px'}}>Grayed out figure represents time periods where race/ethnicity data missingness is greater than 10% and is distinct from data suppression for other reasons. </p></div>
+        </>
+        </Fragment>
+        )
+       
+  },
+
+  getAnnualNoDataGrayBoxForEthn : (hgt, wid) => {
+    return (
+      <Fragment>
+        <>
+        <div style={{ height: hgt + 40, width: wid, textAlign: 'left', display: 'flex', alignItems: 'center', backgroundColor: '#E7E7E7', fontWeight: 'bold', borderRadius: '30px'}}><p style={{ textAlign: 'left', fontWeight: 'bold', padding: '20px'}}>For annual rates, data are available starting with the 12-month period ending in December 2023. Race/ethnicity data prior to 2023 are not shown due to race/ethnicity missingness greater than 10%.</p></div>
         </>
         </Fragment>
         )


### PR DESCRIPTION
QA Findings:

- The first image shows were the y axis is not displaying clearly for percent or Rate. The numbers are bunched together. 
- In the image below the footnotes section is cut off as well as the right grey box needs to be aligned with the left graph data box. 
- The y axis is not displaying clearly for percent or Rate for mobile. 

Business Requirement:

- For the annual rates that end in Jan-Nov 2023, please add the text in the grey box: "For annual rates, data are available starting with the 12-month period ending in December 2023. Race/ethnicity data prior to 2023 are not shown due to race/ethnicity missingness greater than 10%." 

Thanks.