### PR TITLE
Sravan dose surveillance 03032026 0700

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1378,6 +1378,7 @@ const getYears = (startYrInp, endYrInp) => {
           <div className="chartDivAllDem" ref={sexChartRef}>
             <SexChart
                 data={sexAgeMonthly == 'Annual' ? keyedRawUSDataAnnual :  keyedRawUSDataMonthly}
+                jurisCountData={jurisCountData}
                 year={'2023'}
                 width={(!isSmallViewport && !accessible) ? (width * 0.5) : width}
                 height={!isSmallViewport ? (!UtilityFunctions.isCovidPeriodGrayBox(sexAgeMonthly, currentYearSexAge, currentMonthSexAge) ? 640 : 400) : 600}
@@ -1405,6 +1406,7 @@ const getYears = (startYrInp, endYrInp) => {
           <div class={currentState === 'US' ? "chartDivAllDem" : "chartDivAllDem"} ref={ageChartRef}>
             <AgeChart
                 data={sexAgeMonthly == 'Annual' ? keyedRawUSDataAnnual :  keyedRawUSDataMonthly}
+                jurisCountData={jurisCountData}
                 maxes={{'month': 6150,'quarter': 17726}}
                 year={'2023'}
                 width={(!isSmallViewport && !accessible) ? (width * 0.5) : width}
@@ -1435,6 +1437,7 @@ const getYears = (startYrInp, endYrInp) => {
           <div class='chartDivAllDem' ref={sexAgeChartRef}>
             <SexAgeChart 
             data={sexAgeMonthly == 'Annual' ? keyedRawUSDataAnnual :  keyedRawUSDataMonthly}
+            jurisCountData={jurisCountData}
             currentTimeframe={sexAgeMonthly}
             currentYear={currentYearSexAge}
             currentMonth={currentMonthSexAge}
@@ -1474,6 +1477,7 @@ const getYears = (startYrInp, endYrInp) => {
             accessible={accessible}
             widthReduction={(!isSmallViewport && !accessible) ? true : false}
             isEthnGrayBox={isEthnGrayBox()}
+            jurisCount={Number(currentYearSexAge) > 2022 && jurisEthnCountData[currentYearSexAge + String(currentMonthSexAge).padStart(2, '0') + sexAgeMonthly] != null ? jurisEthnCountData[currentYearSexAge + String(currentMonthSexAge).padStart(2, '0') + sexAgeMonthly] : '0'}
             />
           </div>
         </div>
@@ -2545,7 +2549,7 @@ const getYears = (startYrInp, endYrInp) => {
             <table>
               <tr>
                 <td style={{'textAlign': 'center'}}>
-                  <strong>Note: </strong><span>Annual option displays a 12-month rolling average ending at the selected time period [e.g., Feb 2024 - Jan 2025]</span>
+                  <strong>Note: </strong><span>Annual option displays the 12-month rolling average ending at the selected month.</span>
                 </td>
               </tr>
               <br></br>
@@ -2839,7 +2843,7 @@ const getYears = (startYrInp, endYrInp) => {
             <table>
               <tr>
                 <td style={{'textAlign': 'center'}}>
-                  <strong>Note: </strong><span>Annual option displays a 12-month rolling average ending at the selected time period {UtilityFunctions.getPeriod(currentYearBar, currentMonthBar)}</span>
+                  <strong>Note: </strong><span>Annual option displays the 12-month rolling average ending at the selected month.</span>
                 </td>
               </tr>
               <br></br>
@@ -3107,7 +3111,7 @@ const getYears = (startYrInp, endYrInp) => {
               <table>
                 <tr>
                   <td style={{'textAlign': 'center'}}>
-                    <strong>Note: </strong><span>Annual option displays a 12-month rolling average ending at the selected time period {UtilityFunctions.getPeriod(currentYearMap, currentMonthMap)}</span>
+                    <strong>Note: </strong><span>Annual option displays the 12-month rolling average ending at the selected month.</span>
                   </td>
                 </tr>
                 <br></br>
@@ -3325,7 +3329,7 @@ const getYears = (startYrInp, endYrInp) => {
             <table>
               <tr>
                 <td style={{'textAlign': 'center'}}>
-                  <strong>Note: </strong><span>Annual option displays a 12-month rolling average ending at the selected time period {UtilityFunctions.getPeriod(currentYear, currentMonth)}</span>
+                  <strong>Note: </strong><span>Annual option displays the 12-month rolling average ending at the selected month.</span>
                 </td>
               </tr>
             </table>
@@ -3340,12 +3344,12 @@ const getYears = (startYrInp, endYrInp) => {
         <div style={{'width':'100%', 'backgroundColor': getHeaderColor(selectedDrugsSexAge)}}>
           {sexAgeMonthly == 'Monthly' &&
           <h2 className="data-bite-header">
-            Suspected Nonfatal Overdose ED Visits{!accessible ? <sup>†</sup> : ''} Involving {drugOptions[selectedDrugsSexAge[0]].titleAll} per 10,000 Total ED Visits by Sex, Age, and by Sex and Age, and Race/Ethnicity, {monthNames[Number(currentMonthSexAge)] + ' ' + currentYearSexAge}
+            Suspected Nonfatal Overdose ED Visits{!accessible ? <sup>†</sup> : ''} Involving {drugOptions[selectedDrugsSexAge[0]].titleAll} per 10,000 Total ED Visits by Sex, Age, Sex and Age, and Race/Ethnicity, {monthNames[Number(currentMonthSexAge)] + ' ' + currentYearSexAge}
           </h2>
           }
           {sexAgeMonthly == 'Annual' &&
           <h2 className="data-bite-header">
-            Suspected Nonfatal Overdose ED Visits{!accessible ? <sup>†</sup> : ''} Involving {drugOptions[selectedDrugsSexAge[0]].titleAll} per 10,000 Total ED Visits by Sex, Age, and by Sex and Age, and Race/Ethnicity, {UtilityFunctions.getPeriod(currentYearSexAge, currentMonthSexAge)}
+            Suspected Nonfatal Overdose ED Visits{!accessible ? <sup>†</sup> : ''} Involving {drugOptions[selectedDrugsSexAge[0]].titleAll} per 10,000 Total ED Visits by Sex, Age, Sex and Age, and Race/Ethnicity, {UtilityFunctions.getPeriod(currentYearSexAge, currentMonthSexAge)}
           </h2>
           }
         </div>
@@ -3425,7 +3429,7 @@ const getYears = (startYrInp, endYrInp) => {
                             <table>
                               <tr>
                                 <td style={{'textAlign': !isSmallViewport ? 'center' : 'left'}}>
-                                  <strong>Note: </strong><span>Annual option displays a 12-month rolling average ending at the selected time period {UtilityFunctions.getPeriod(currentYearSexAge, currentMonthSexAge)}</span>
+                                  <strong>Note: </strong><span>Annual option displays the 12-month rolling average ending at the selected month.</span>
                                 </td>
                               </tr>
                               <br></br>
@@ -3546,7 +3550,7 @@ const getYears = (startYrInp, endYrInp) => {
                             <table>
                               <tr>
                                 <td style={{'textAlign': !isSmallViewport ? 'center' : 'left'}}>
-                                  <strong>Note: </strong><span>Annual option displays a 12-month rolling average ending at the selected time period {UtilityFunctions.getPeriod(currentYearSexAge, currentMonthSexAge)}</span>
+                                  <strong>Note: </strong><span>Annual option displays the 12-month rolling average ending at the selected month.</span>
                                 </td>
                               </tr>
                               <br></br>

--- a/src/App.js
+++ b/src/App.js
@@ -240,6 +240,8 @@ export default function App( params ) {
   const [selectedDrugsSexAge, setselectedDrugsSexAge] = useState(['all']);
   const [selectedDrugsState, setselectedDrugsState] = useState(['all']);
 
+  const [highlightedDrugLine, setHighlightedDrugLine] = useState('');
+
   const [showConsiderations, setShowConsiderations] = useState(false);
   const [showFootNotes, setShowFootNotes] = useState(false);
   const [showLineChart, setShowLineChart] = useState(true);
@@ -1339,6 +1341,7 @@ const getYears = (startYrInp, endYrInp) => {
               selectedDrugs={selectedDrugsLine} 
               currentDataSource={'ED'}
               accessible={accessible}
+              highlightedDrug={highlightedDrugLine}
               />
             </div>
           </div>
@@ -1347,7 +1350,7 @@ const getYears = (startYrInp, endYrInp) => {
     
     </table>
   </>,
-  [timelineLine, currentDrug, currentStateLine, currentYear, currentMonth, width, showPercent,showOverall, isPeriod, selectedDrugsLine, lookupPeriodStartYearM, lookupPeriodStartMonthM, lookupPeriodEndYearM, lookupPeriodEndMonthM, lookupPeriodStartYearA, lookupPeriodStartMonthA, lookupPeriodEndYearA, lookupPeriodEndMonthA]);
+  [timelineLine, currentDrug, currentStateLine, currentYear, currentMonth, width, showPercent,showOverall, isPeriod, selectedDrugsLine, lookupPeriodStartYearM, lookupPeriodStartMonthM, lookupPeriodEndYearM, lookupPeriodEndMonthM, lookupPeriodStartYearA, lookupPeriodStartMonthA, lookupPeriodEndYearA, lookupPeriodEndMonthA, highlightedDrugLine]);
 
   const usaMapMemo = useMemo(() =>
       <>
@@ -1490,8 +1493,21 @@ const getYears = (startYrInp, endYrInp) => {
       <div className="loading-spinner"></div>
   </div>;
 
+  const cleanupLineLabels = () => {
+
+    const allLabels = document?.getElementsByClassName("linePanelDrug");
+    Array.prototype.forEach.call(allLabels, function(el) {
+      if (!selectedDrugsLine.includes(el.id.replace('line-panel-',''))) {
+        let elm = document.getElementById(el.id);
+        elm.style.fontWeight = "normal";
+        elm.style.fontSize = !isSmallViewport ? 16 : 14;
+      }
+    });
+  }
+
   useEffect(() => {
     ReactTooltip.rebuild();
+    cleanupLineLabels();
   });
  
   if (endUSMonthYearForSliderM == null || endUSMonthYearForSliderM?.length == 0) {
@@ -1601,6 +1617,7 @@ const getYears = (startYrInp, endYrInp) => {
       if (selectedDrugsLine.includes(drug)) {
         if (selectedDrugsLine.length > 1) {
           setselectedDrugsLine(selectedDrugsLine.filter(dr=>dr !== drug))
+          setHighlightedDrugLine('none');
         }
       }
       else
@@ -1613,6 +1630,37 @@ const getYears = (startYrInp, endYrInp) => {
       setselectedDrugsLine([drug])
     }
   }
+
+  const handleDrugLblMainClick = (event) => {
+
+    let elemen = document.getElementById(event.currentTarget.id);
+    let drg = event.currentTarget.id.replace('line-panel-','');
+
+    if (!selectedDrugsLine.includes(drg))
+      return;
+
+    if (UtilityFunctions.isBold(elemen))
+    {
+      elemen.style.fontWeight = "normal";
+      elemen.style.fontSize = !isSmallViewport ? 16 : 14;
+      setHighlightedDrugLine('none');
+      return;
+    }
+    else {
+      setHighlightedDrugLine(drg)
+    }
+    
+    const allLabels = document?.getElementsByClassName("linePanelDrug");
+    Array.prototype.forEach.call(allLabels, function(el) {
+      let elm = document.getElementById(el.id);
+      elm.style.fontWeight = "normal";
+      elm.style.fontSize = !isSmallViewport ? 16 : 14;
+    });
+
+    let elem = document.getElementById(event.currentTarget.id);
+    elem.style.fontWeight = "bold";
+    elem.style.fontSize = (!isSmallViewport ? 16 : 14) + 2;
+  };
 
   const getDrugControlsLine = () => {
     const entries = Object.entries(drugOptions);
@@ -1628,7 +1676,7 @@ const getYears = (startYrInp, endYrInp) => {
               index < 4 &&
                 <div class={`drugDiv-${drug[0]}`}>
                   <span class={(selectedDrugsLine.includes(drug[0])) ? drug[0] : 'notSelectedLine'} onClick={(event) => { handleDrugSelectionsLineChange(event, drug[0]) }}></span>
-                  <label key={drug[0]} class="lblDrug">{drug[1].titleForDropDown}</label>
+                  <label key={drug[0]} id={`line-panel-${drug[0]}`} class={`lblDrug linePanelDrug linePanelDrug-${drug[0]}`} onClick={handleDrugLblMainClick}>{drug[1].titleForDropDown}</label>
                 </div>
                 
             ))
@@ -1642,7 +1690,7 @@ const getYears = (startYrInp, endYrInp) => {
               index >= 4 &&
               <div class={`drugDiv-${drug[0]}`}>
                       <span class={(selectedDrugsLine.includes(drug[0])) ? drug[0] : 'notSelectedLine'} onClick={(event) => { handleDrugSelectionsLineChange(event, drug[0]) }}></span>
-                      <label key={drug[0]} class="lblDrug">{drug[1].titleForDropDown}</label>
+                      <label key={drug[0]} id={`line-panel-${drug[0]}`} class={`lblDrug linePanelDrug linePanelDrug-${drug[0]}`} onClick={handleDrugLblMainClick}>{drug[1].titleForDropDown}</label>
                     </div>
             ))
           }
@@ -1661,7 +1709,7 @@ const getYears = (startYrInp, endYrInp) => {
                     <div>
                       <div class={`drugDiv-${drug[0]}`}>
                         <span class={(selectedDrugsLine.includes(drug[0])) ? drug[0] : 'notSelectedLine'} onClick={(event) => { handleDrugSelectionsLineChange(event, drug[0]) }}></span>
-                        <label key={drug[0]} class="lblDrug">{drug[1].titleForDropDown}</label>
+                        <label key={drug[0]} id={`line-panel-${drug[0]}`} class={`lblDrug linePanelDrug linePanelDrug-${drug[0]}`} onClick={handleDrugLblMainClick}>{drug[1].titleForDropDown}</label>
                       </div>
                       <br></br>
                       </div>

--- a/src/App.js
+++ b/src/App.js
@@ -3125,15 +3125,15 @@ const getYears = (startYrInp, endYrInp) => {
       </section>
 
         {/* State Chart Start */}
-        <div style={{'width':'100%', 'backgroundColor': drugColor}}>
+        <div style={{'width':'100%', 'backgroundColor': drugOptions[selectedDrugsState[0]].color}}>
           {timeline == 'Monthly' &&
           <h2 className="data-bite-header">
-            Suspected Nonfatal Overdose ED Visits Involving {drugOptions[currentDrug].titleAll} per 10,000 Total ED visits by Jurisdiction, {monthNames[Number(currentMonth)] + ' ' + currentYear}
+            Suspected Nonfatal Overdose ED Visits Involving {drugOptions[selectedDrugsState[0]].titleAll} per 10,000 Total ED visits by Jurisdiction, {monthNames[Number(currentMonth)] + ' ' + currentYear}
           </h2>
           }
           {timeline == 'Annual' &&
           <h2 className="data-bite-header">
-            Suspected Nonfatal Overdose ED Visits Involving {drugOptions[currentDrug].titleAll} per 10,000 Total ED visits by Jurisdiction, {UtilityFunctions.getPeriod(currentYear, currentMonth)}
+            Suspected Nonfatal Overdose ED Visits Involving {drugOptions[selectedDrugsState[0]].titleAll} per 10,000 Total ED visits by Jurisdiction, {UtilityFunctions.getPeriod(currentYear, currentMonth)}
           </h2>
           }
         </div>

--- a/src/components/AgeChart.js
+++ b/src/components/AgeChart.js
@@ -306,7 +306,7 @@ function AgeChart(params) {
           isSmallViewport={isSmallViewport}
           currentDataType={currentDataType}
         />
-        {!isSmallViewport && <table>
+        {/* {!isSmallViewport && <table>
             {!UtilityFunctions.allDataIsSupressed(filteredData) &&
             <tr>
               <td>
@@ -315,7 +315,7 @@ function AgeChart(params) {
             </tr>
             }
         </table>
-        }
+        } */}
         {isSmallViewport && <table>
           <tr>
               <td>
@@ -326,7 +326,7 @@ function AgeChart(params) {
                     <tr>
                       <td>
                         <div><span><small><i><sup>*</sup>Data suppressed.</i></small></span></div>
-                        {!UtilityFunctions.allDataIsSupressed(filteredData) && <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div> }
+                        {/* {!UtilityFunctions.allDataIsSupressed(filteredData) && <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div> } */}
                         <span></span>
                       </td>
                     </tr>
@@ -435,9 +435,9 @@ function AgeChart(params) {
         </svg>
         <div>
           <table>
-            {!UtilityFunctions.allDataIsSupressed(filteredData) &&
+           {/*  {!UtilityFunctions.allDataIsSupressed(filteredData) &&
               <tr><td><small><i>{getMissingNote(missingData)}</i></small></td></tr>
-            }
+            } */}
             {!UtilityFunctions.allDataIsSupressed(filteredData) &&
               <tr><td><small><i><sup>*</sup>{'Data suppressed.'}</i></small></td></tr>
             }

--- a/src/components/AgeChart.js
+++ b/src/components/AgeChart.js
@@ -307,7 +307,7 @@ function AgeChart(params) {
           currentDataType={currentDataType}
         />
         {!isSmallViewport && <table>
-            {!UtilityFunctions.allDataIsSupressed(filteredData) && currentDataType == 'rate' &&
+            {!UtilityFunctions.allDataIsSupressed(filteredData) && currentDataType == 'placeHolder' &&
             <tr>
               <td>
                 <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div>
@@ -326,7 +326,7 @@ function AgeChart(params) {
                     <tr>
                       <td>
                         <div><span><small><i><sup>*</sup>Data suppressed.</i></small></span></div>
-                        {!UtilityFunctions.allDataIsSupressed(filteredData) && currentDataType == 'rate' && <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div> }
+                        {!UtilityFunctions.allDataIsSupressed(filteredData) && currentDataType == 'placeHolder' && <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div> }
                         <span></span>
                       </td>
                     </tr>
@@ -435,7 +435,7 @@ function AgeChart(params) {
         </svg>
         <div>
           <table>
-            {!UtilityFunctions.allDataIsSupressed(filteredData) && currentDataType == 'rate' &&
+            {!UtilityFunctions.allDataIsSupressed(filteredData) && currentDataType == 'placeHolder' &&
               <tr><td><small><i>{getMissingNote(missingData)}</i></small></td></tr>
             }
             {!UtilityFunctions.allDataIsSupressed(filteredData) &&

--- a/src/components/AgeChart.js
+++ b/src/components/AgeChart.js
@@ -229,7 +229,7 @@ const getMaxValue = (fdata) => {
 
 function AgeChart(params) {
 
-  const { data, year, width, height, header, el, currentDrug, drugOptions, currentTimeLine, currentYear, currentMonth, currentDataType, accessible, widthReduction } = params;
+  const { data, jurisCountData, year, width, height, header, el, currentDrug, drugOptions, currentTimeLine, currentYear, currentMonth, currentDataType, accessible, widthReduction } = params;
   const isSmallViewport = width < 550 && !widthReduction;
   const [ animated, setAnimated ] = useState(false);
 
@@ -282,7 +282,7 @@ function AgeChart(params) {
     setTimeout(onScroll, 50); // eslint-disable-next-line
   }, []);
 
-  if (!accessible && UtilityFunctions.isCovidPeriodGrayBox(currentTimeLine, currentYear, currentMonth))
+  if (UtilityFunctions.isCovidPeriodGrayBox(currentTimeLine, currentYear, currentMonth))
       return UtilityFunctions.getCovidGrayBox(height, width);
     
   return width > 0 && 
@@ -293,8 +293,8 @@ function AgeChart(params) {
         <DataTable508
           data={AccessibilityFunctions.generateAgeChartData(filteredData)}
           labelOverrides={{
-            'rate': !isSmallViewport ? (currentDataType == 'rate' ? 'Rate' : 'Percent') + ' of suspected nonfatal overdoses involving ' + drugOptions[currentDrug].titleAll + ' per 10,000 Total ED Visits' : (currentDataType == 'rate' ? 'Rate' : 'Percent'),
-            'Sex': !isSmallViewport ? 'By Age (In years)' : 'By Age',
+            'rate': !isSmallViewport ? (currentDataType == 'rate' ? 'Rate' : 'Percent') + ' of suspected nonfatal overdoses involving ' + drugOptions[currentDrug].titleAll + (currentDataType == 'rate' ? ' per 10,000 Total ED Visits' : '') : (currentDataType == 'rate' ? 'Rate' : 'Percent'),
+            'Sex': (!isSmallViewport ? 'By Age (In years) (' : 'By Age ') + ((jurisCountData != null && Object.keys(jurisCountData).length > 0) ? jurisCountData[currentYear + currentMonth.padStart(2, '0') + currentTimeLine] : '0') + ' Jurisdictions)',
             '0–14': '<15'
           }}
           xAxisKey={'Sex'}
@@ -355,6 +355,7 @@ function AgeChart(params) {
                       getFormattedValue(value)
                   }
                   labelOffset={60}
+                  numTicks={5}
                 />
 
                 {filteredData.map(d => (

--- a/src/components/AgeChart.js
+++ b/src/components/AgeChart.js
@@ -283,7 +283,7 @@ function AgeChart(params) {
   }, []);
 
   if (UtilityFunctions.isCovidPeriodGrayBox(currentTimeLine, currentYear, currentMonth))
-      return UtilityFunctions.getCovidGrayBox(height, width);
+      return UtilityFunctions.getCovidGrayBox(height, width, accessible ? 'By Age (In years): ' : '');
     
   return width > 0 && 
       (

--- a/src/components/AgeChart.js
+++ b/src/components/AgeChart.js
@@ -307,7 +307,7 @@ function AgeChart(params) {
           currentDataType={currentDataType}
         />
         {!isSmallViewport && <table>
-            {!UtilityFunctions.allDataIsSupressed(filteredData) && currentDataType == 'percent' &&
+            {!UtilityFunctions.allDataIsSupressed(filteredData) && currentDataType == 'rate' &&
             <tr>
               <td>
                 <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div>
@@ -326,7 +326,7 @@ function AgeChart(params) {
                     <tr>
                       <td>
                         <div><span><small><i><sup>*</sup>Data suppressed.</i></small></span></div>
-                        {!UtilityFunctions.allDataIsSupressed(filteredData) && currentDataType == 'percent' && <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div> }
+                        {!UtilityFunctions.allDataIsSupressed(filteredData) && currentDataType == 'rate' && <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div> }
                         <span></span>
                       </td>
                     </tr>
@@ -435,7 +435,7 @@ function AgeChart(params) {
         </svg>
         <div>
           <table>
-            {!UtilityFunctions.allDataIsSupressed(filteredData) && currentDataType == 'percent' &&
+            {!UtilityFunctions.allDataIsSupressed(filteredData) && currentDataType == 'rate' &&
               <tr><td><small><i>{getMissingNote(missingData)}</i></small></td></tr>
             }
             {!UtilityFunctions.allDataIsSupressed(filteredData) &&

--- a/src/components/AgeChart.js
+++ b/src/components/AgeChart.js
@@ -306,8 +306,8 @@ function AgeChart(params) {
           isSmallViewport={isSmallViewport}
           currentDataType={currentDataType}
         />
-        {/* {!isSmallViewport && <table>
-            {!UtilityFunctions.allDataIsSupressed(filteredData) &&
+        {!isSmallViewport && <table>
+            {!UtilityFunctions.allDataIsSupressed(filteredData) && currentDataType == 'percent' &&
             <tr>
               <td>
                 <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div>
@@ -315,7 +315,7 @@ function AgeChart(params) {
             </tr>
             }
         </table>
-        } */}
+        }
         {isSmallViewport && <table>
           <tr>
               <td>
@@ -326,7 +326,7 @@ function AgeChart(params) {
                     <tr>
                       <td>
                         <div><span><small><i><sup>*</sup>Data suppressed.</i></small></span></div>
-                        {/* {!UtilityFunctions.allDataIsSupressed(filteredData) && <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div> } */}
+                        {!UtilityFunctions.allDataIsSupressed(filteredData) && currentDataType == 'percent' && <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div> }
                         <span></span>
                       </td>
                     </tr>
@@ -435,9 +435,9 @@ function AgeChart(params) {
         </svg>
         <div>
           <table>
-           {/*  {!UtilityFunctions.allDataIsSupressed(filteredData) &&
+            {!UtilityFunctions.allDataIsSupressed(filteredData) && currentDataType == 'percent' &&
               <tr><td><small><i>{getMissingNote(missingData)}</i></small></td></tr>
-            } */}
+            }
             {!UtilityFunctions.allDataIsSupressed(filteredData) &&
               <tr><td><small><i><sup>*</sup>{'Data suppressed.'}</i></small></td></tr>
             }

--- a/src/components/BarChart.js
+++ b/src/components/BarChart.js
@@ -168,7 +168,7 @@ function BarChart(params) {
       return 'per 10,000 Total ED Visits';
   }
 
-if (!accessible && UtilityFunctions.isCovidPeriodGrayBox(currentTimeframe, currentYear, currentMonth))
+if (UtilityFunctions.isCovidPeriodGrayBox(currentTimeframe, currentYear, currentMonth))
       return UtilityFunctions.getCovidGrayBox(height, width);
 
   return width > 0 && (

--- a/src/components/DataTable508.js
+++ b/src/components/DataTable508.js
@@ -113,7 +113,7 @@ function DataTable508(params) {
           <thead>
           <tr>
               <th className={'keepSticky'} scope="col" rowspan="2">{labelOverrides[xAxisKey] || formatLabel(xAxisKey)}</th>
-              {colSpan != null && <th key={'abcd'} scope="col" colspan={colSpan} className={'centerAlign'}>{(currentDataType == 'percent' ? 'Percent' : 'Rate') + ' of suspected nonfatal overdoses' + (drugName != null ? ' involving ' + drugName : '') + ' per 10,000 Total ED Visits'}</th>}
+              {colSpan != null && <th key={'abcd'} scope="col" colspan={colSpan} className={'centerAlign'}>{(currentDataType == 'percent' ? 'Percent' : 'Rate') + ' of suspected nonfatal overdoses' + (drugName != null ? ' involving ' + drugName : '') + (currentDataType == 'rate' ? ' per 10,000 Total ED Visits' : '')}</th>}
             </tr>
             <tr>
               {!isArray && data && [data].map((d, index) => 

--- a/src/components/EthnicityChart.js
+++ b/src/components/EthnicityChart.js
@@ -595,9 +595,9 @@ function EthnicityChart(params) {
           {!dummy && !UtilityFunctions.dataIsSupressedEthn(filteredData) &&
           <tr>
             <td>
-              <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div>
+              {/* <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div> */}
               <div><span><small><i><sup>*</sup>{'The race/ethnicity figure excludes data from jurisdictions that had >= 15% missing race/ethnicity data during the selected time period, as well as those who do not participate in DOSE-SYS or who do not have data for this time period. ' + (areJurisExcluded() ? 'This figure excludes data from ' : '') + getJurisExcluded() + (areJurisExcluded() ? '.' : '')}</i></small></span></div>
-              <div><span><small><i>{'AI/AN, American Indian/Alaska Native. NH/PI, Native Hawaiian or other Pacific Islander.'}</i></small></span></div>
+              <div><span><small><i><sup>¶</sup>{'AI/AN, American Indian/Alaska Native. NH/PI, Native Hawaiian or other Pacific Islander.'}</i></small></span></div>
             </td>
           </tr>
           }
@@ -612,13 +612,13 @@ function EthnicityChart(params) {
             <br></br>
                     <tr>
                       <td>
-                        {(!dummy && !UtilityFunctions.dataIsSupressedEthn(filteredData)) && <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div> }
-                        {<br></br>}
+                        {/* {(!dummy && !UtilityFunctions.dataIsSupressedEthn(filteredData)) && <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div> }
+                        {<br></br>} */}
                         <div><span><small><i><sup>*</sup>Data suppressed.</i></small></span></div>
                         {<br></br>}
                         {(!dummy && !UtilityFunctions.dataIsSupressedEthn(filteredData)) && <div><span><small><i><sup>*</sup>{'The race/ethnicity figure excludes data from jurisdictions that had >= 15% missing race/ethnicity data during the selected time period, as well as those who do not participate in DOSE-SYS or who do not have data for this time period.  ' + (areJurisExcluded() ? 'This figure excludes data from ' : '') + getJurisExcluded() + (areJurisExcluded() ? '.' : '')}</i></small></span></div>}
                         {<br></br>}
-                        {(!dummy && !UtilityFunctions.dataIsSupressedEthn(filteredData)) && <div><span><small><i>{'AI/AN, American Indian/Alaska Native. NH/PI, Native Hawaiian or other Pacific Islander.'}</i></small></span></div>}
+                        {(!dummy && !UtilityFunctions.dataIsSupressedEthn(filteredData)) && <div><span><small><i><sup>¶</sup>{'AI/AN, American Indian/Alaska Native. NH/PI, Native Hawaiian or other Pacific Islander.'}</i></small></span></div>}
                       </td>
                     </tr>
                 </table>
@@ -672,11 +672,11 @@ function EthnicityChart(params) {
           </Group>
         </svg>
         {!isEthnGrayBox &&
-        <div style={{height: !isSmallViewport ? '320px' : '540px'}}>
+        <div style={{height: !isSmallViewport ? '340px' : '560px'}}>
             <table>
-              {Object.keys(filteredData).length > 0 &&
+              {/* {Object.keys(filteredData).length > 0 &&
                 <tr><td><small><i>{getMissingNote(missingData)}</i></small></td></tr>
-              }
+              } */}
               {Object.keys(filteredData).length > 0 &&
                 <tr><td><small><i><sup>*</sup>{'Data suppressed.'}</i></small></td></tr>
               }

--- a/src/components/EthnicityChart.js
+++ b/src/components/EthnicityChart.js
@@ -418,7 +418,7 @@ const getEthnGroupsDummy = (data) => {
 
 function EthnicityChart(params) {
 
-  const { data, dataJurisExcl, currentTimeframe, currentDrug, currentYear, currentMonth, stateNames, currentDataType, width, height, drugOptions, accessible, widthReduction, isEthnGrayBox } = params;
+  const { data, dataJurisExcl, currentTimeframe, currentDrug, currentYear, currentMonth, stateNames, currentDataType, width, height, drugOptions, accessible, widthReduction, isEthnGrayBox, jurisCount } = params;
 
   const ethnGroupsReal = getEthnGroups(data, currentTimeframe, currentYear, currentMonth)
   const filteredDataReal = getFilteredData(data, ethnGroupsReal, currentDrug, currentTimeframe, currentYear, currentMonth, currentDataType);
@@ -434,7 +434,7 @@ function EthnicityChart(params) {
 
   const isSmallViewport = width < 550 && !widthReduction;
   const fontSize = 16;
-  const margin = { top: 15, bottom: 145, left: isSmallViewport ? 120 : 110, right: isSmallViewport ? 0 : 15 };
+  const margin = { top: 15, bottom: 145, left: isSmallViewport ? 125 : 140, right: isSmallViewport ? 0 : 15 };
 
   const xMax = width - margin.left - margin.right;
   const yMax = height - margin.top - margin.bottom - (isSmallViewport ? 10 : 0);
@@ -502,10 +502,10 @@ function EthnicityChart(params) {
     return (
       <g key={d[yKey]}>
 
-        {d[xKey] >= 0 && <path d={d[xKey] < 0.9 ? Utils.horizontalBarPathDem_NR(isSmallViewport ? 5 : 35, yScale(d[yKey]), xPos, yScale.bandwidth()) : Utils.horizontalBarPathDem(true, isSmallViewport ? 5 : 35, yScale(d[yKey]), xPos, yScale.bandwidth(), 3, yScale.bandwidth() * .1)} fill={isNaN(d[xKey]) ? 'transparent' : drugOptions[currentDrug].color} stroke={drugOptions[currentDrug].color} opacity={1} data-tip={xTip} />}
+        {d[xKey] >= 0 && <path d={d[xKey] < 0.9 ? Utils.horizontalBarPathDem_NR(isSmallViewport ? 5 : 65, yScale(d[yKey]), xPos, yScale.bandwidth()) : Utils.horizontalBarPathDem(true, isSmallViewport ? 5 : 65, yScale(d[yKey]), xPos, yScale.bandwidth(), 3, yScale.bandwidth() * .1)} fill={isNaN(d[xKey]) ? 'transparent' : drugOptions[currentDrug].color} stroke={drugOptions[currentDrug].color} opacity={1} data-tip={xTip} />}
         {Number(d[xKey]) >= 0 && 
         <Text 
-          x={((xPos + (isSmallViewport ? (Number(d[xKey]) >= 100 ? 13 : 5) : (Number(d[xKey]) >= 100 ? 60 : 50)) + (currentDataType == 'rate' ? 30 : 40)))} 
+          x={((xPos + (isSmallViewport ? (Number(d[xKey]) >= 100 ? 13 : 5) : (Number(d[xKey]) >= 100 ? 90 : 80)) + (currentDataType == 'rate' ? 30 : 40)))} 
           y={yScale(d[yKey]) + (yScale.bandwidth() / 2) + 5} 
           textAnchor={'end'} 
           fill="#000000"
@@ -515,7 +515,7 @@ function EthnicityChart(params) {
         }
           {Number(d[xKey])?.toFixed(1) == -3.0 &&
             <Text 
-            x={(isSmallViewport ? 10 : 40)}
+            x={(isSmallViewport ? 10 : 70)}
             y={yScale(d[yKey]) + (yScale.bandwidth() / 2) + 5}
             textAnchor={'end'} 
             fill={drugOptions[currentDrug].color}
@@ -526,7 +526,7 @@ function EthnicityChart(params) {
         }
         {Number(d[xKey])?.toFixed(1) == -1.0 &&
             <Text 
-            x={(isSmallViewport ? 10 : 40)}
+            x={(isSmallViewport ? 10 : 70)}
             y={yScale(d[yKey]) + (yScale.bandwidth() / 2) + 5}
             textAnchor={'end'} 
             fill={drugOptions[currentDrug].color}
@@ -537,7 +537,7 @@ function EthnicityChart(params) {
         }
         {Number(d[xKey])?.toFixed(1) == -9.0 &&
             <Text 
-            x={(isSmallViewport ? 20 : 50)}
+            x={(isSmallViewport ? 20 : 80)}
             y={yScale(d[yKey]) + (yScale.bandwidth() / 2) + 5}
             textAnchor={'end'} 
             fill={drugOptions[currentDrug].color}
@@ -552,7 +552,7 @@ function EthnicityChart(params) {
     )
   }
 
-  if (Number(currentYear) < 2023 && !accessible)
+  if (Number(currentYear) < 2023)
   {
     if (UtilityFunctions.isCovidPeriodGrayBox(currentTimeframe, currentYear, currentMonth))
         return UtilityFunctions.getCovidGrayBox(height, width);
@@ -560,7 +560,7 @@ function EthnicityChart(params) {
       return UtilityFunctions.getNoDataGrayBoxForEthn(height + (currentDataType == 'percent' ? 80 : 40), width);
   }
 
-  if (Number(currentYear) == 2023 && Number(currentMonth) < 12 && currentTimeframe == 'Annual' && !accessible)
+  if (Number(currentYear) == 2023 && Number(currentMonth) < 12 && currentTimeframe == 'Annual')
   {
       return UtilityFunctions.getAnnualNoDataGrayBoxForEthn(height + (currentDataType == 'percent' ? 80 : 40), width);
   }
@@ -572,8 +572,8 @@ function EthnicityChart(params) {
         <DataTable508
           data={AccessibilityFunctions.generateEthnChartData(filteredData)}
           labelOverrides={{
-            'val': !isSmallViewport ? (currentDataType == 'rate' ? 'Rate' : 'Percent') + ' of suspected nonfatal overdoses involving ' + drugOptions[currentDrug].titleAll + ' per 10,000 Total ED Visits' : (currentDataType == 'rate' ? 'Rate' : 'Percent'),
-            'Age Group': !isSmallViewport ? 'By Race/Ethnicity' : 'By Race/Ethnicity',
+            'val': !isSmallViewport ? (currentDataType == 'rate' ? 'Rate' : 'Percent') + ' of suspected nonfatal overdoses involving ' + drugOptions[currentDrug].titleAll + (currentDataType == 'rate' ? ' per 10,000 Total ED Visits' : '') : (currentDataType == 'rate' ? 'Rate' : 'Percent'),
+            'Age Group': !isSmallViewport ? 'By Race/Ethnicity (' + jurisCount + ' Jurisdictions)*' : 'By Race/Ethnicity (' + jurisCount + ' Jurisdictions)*',
           }}
           xAxisKey={'Age Group'}
           transforms={{
@@ -595,8 +595,9 @@ function EthnicityChart(params) {
           {!dummy && !UtilityFunctions.dataIsSupressedEthn(filteredData) &&
           <tr>
             <td>
-              <div><span><small><i><sup>*</sup>{getMissingNote(missingData)}</i></small></span></div>
-              <div><span><small><i>{'The race/ethnicity figure excludes data from jurisdictions that had >= 15% missing race/ethnicity data during the selected time period, as well as those who do not participate in DOSE-SYS or who do not have data for this time period. ' + (areJurisExcluded() ? 'This figure excludes data from ' : '') + getJurisExcluded() + (areJurisExcluded() ? '.' : '')}</i></small></span></div>
+              <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div>
+              <div><span><small><i><sup>*</sup>{'The race/ethnicity figure excludes data from jurisdictions that had >= 15% missing race/ethnicity data during the selected time period, as well as those who do not participate in DOSE-SYS or who do not have data for this time period. ' + (areJurisExcluded() ? 'This figure excludes data from ' : '') + getJurisExcluded() + (areJurisExcluded() ? '.' : '')}</i></small></span></div>
+              <div><span><small><i>{'AI/AN, American Indian/Alaska Native. NH/PI, Native Hawaiian or other Pacific Islander.'}</i></small></span></div>
             </td>
           </tr>
           }
@@ -615,7 +616,9 @@ function EthnicityChart(params) {
                         {<br></br>}
                         <div><span><small><i><sup>*</sup>Data suppressed.</i></small></span></div>
                         {<br></br>}
-                        {(!dummy && !UtilityFunctions.dataIsSupressedEthn(filteredData)) && <div><span><small><i>{'The race/ethnicity figure excludes data from jurisdictions that had >= 15% missing race/ethnicity data during the selected time period, as well as those who do not participate in DOSE-SYS or who do not have data for this time period.  ' + (areJurisExcluded() ? 'This figure excludes data from ' : '') + getJurisExcluded() + (areJurisExcluded() ? '.' : '')}</i></small></span></div>}
+                        {(!dummy && !UtilityFunctions.dataIsSupressedEthn(filteredData)) && <div><span><small><i><sup>*</sup>{'The race/ethnicity figure excludes data from jurisdictions that had >= 15% missing race/ethnicity data during the selected time period, as well as those who do not participate in DOSE-SYS or who do not have data for this time period.  ' + (areJurisExcluded() ? 'This figure excludes data from ' : '') + getJurisExcluded() + (areJurisExcluded() ? '.' : '')}</i></small></span></div>}
+                        {<br></br>}
+                        {(!dummy && !UtilityFunctions.dataIsSupressedEthn(filteredData)) && <div><span><small><i>{'AI/AN, American Indian/Alaska Native. NH/PI, Native Hawaiian or other Pacific Islander.'}</i></small></span></div>}
                       </td>
                     </tr>
                 </table>
@@ -635,16 +638,16 @@ function EthnicityChart(params) {
               fill: '#000066',
               textAnchor: 'end',
               verticalAnchor: 'middle',
-              angle: (45),
+              angle: (isSmallViewport ? 45 : 0),
             })}
-            left={!isSmallViewport ? 35 : 5}
+            left={!isSmallViewport ? 65 : 5}
             hideTicks
             hideAxisLine
           />
           <AxisBottom
                 top={yMax}
                 scale={xScale}
-                left={!isSmallViewport ? 35 : 5}
+                left={!isSmallViewport ? 65 : 5}
                 numTicks={isSmallViewport ? 3 : 6}
                 tickStroke="none"
                 tickFormat={value => 
@@ -669,7 +672,7 @@ function EthnicityChart(params) {
           </Group>
         </svg>
         {!isEthnGrayBox &&
-        <div style={{height: !isSmallViewport ? '300px' : '520px'}}>
+        <div style={{height: !isSmallViewport ? '320px' : '540px'}}>
             <table>
               {Object.keys(filteredData).length > 0 &&
                 <tr><td><small><i>{getMissingNote(missingData)}</i></small></td></tr>
@@ -682,6 +685,9 @@ function EthnicityChart(params) {
               }
               {Object.keys(filteredData).length > 0 &&
                 <tr><td><small><i><sup>§</sup>{'The race/ethnicity figure excludes data from jurisdictions that had >= 15% missing race/ethnicity data during the selected time period, as well as those who do not participate in DOSE-SYS or who do not have data for this time period.  ' + (areJurisExcluded() ? 'This figure excludes data from ' : '') + getJurisExcluded() + (areJurisExcluded() ? '.' : '')}</i></small></td></tr>
+              }
+              {Object.keys(filteredData).length > 0 &&
+                <tr><td><small><i><sup>¶</sup>{'AI/AN, American Indian/Alaska Native. NH/PI, Native Hawaiian or other Pacific Islander.'}</i></small></td></tr>
               }
             </table>
           </div>

--- a/src/components/EthnicityChart.js
+++ b/src/components/EthnicityChart.js
@@ -595,7 +595,7 @@ function EthnicityChart(params) {
           {!dummy && !UtilityFunctions.dataIsSupressedEthn(filteredData) && 
           <tr>
             <td>
-              {currentDataType == 'percent' && <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div>}
+              {currentDataType == 'rate' && <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div>}
               <div><span><small><i><sup>*</sup>{'The race/ethnicity figure excludes data from jurisdictions that had >= 15% missing race/ethnicity data during the selected time period, as well as those who do not participate in DOSE-SYS or who do not have data for this time period. ' + (areJurisExcluded() ? 'This figure excludes data from ' : '') + getJurisExcluded() + (areJurisExcluded() ? '.' : '')}</i></small></span></div>
               <div><span><small><i><sup>¶</sup>{'AI/AN, American Indian/Alaska Native. NH/PI, Native Hawaiian or other Pacific Islander.'}</i></small></span></div>
             </td>
@@ -612,7 +612,7 @@ function EthnicityChart(params) {
             <br></br>
                     <tr>
                       <td>
-                        {(!dummy && !UtilityFunctions.dataIsSupressedEthn(filteredData)) && currentDataType == 'percent' && <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div> }
+                        {(!dummy && !UtilityFunctions.dataIsSupressedEthn(filteredData)) && currentDataType == 'rate' && <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div> }
                         {<br></br>}
                         <div><span><small><i><sup>*</sup>Data suppressed.</i></small></span></div>
                         {<br></br>}
@@ -674,7 +674,7 @@ function EthnicityChart(params) {
         {!isEthnGrayBox &&
         <div style={{height: !isSmallViewport ? '340px' : '560px'}}>
             <table>
-              {Object.keys(filteredData).length > 0 && currentDataType == 'percent' &&
+              {Object.keys(filteredData).length > 0 && currentDataType == 'rate' &&
                 <tr><td><small><i>{getMissingNote(missingData)}</i></small></td></tr>
               }
               {Object.keys(filteredData).length > 0 &&

--- a/src/components/EthnicityChart.js
+++ b/src/components/EthnicityChart.js
@@ -555,14 +555,14 @@ function EthnicityChart(params) {
   if (Number(currentYear) < 2023)
   {
     if (UtilityFunctions.isCovidPeriodGrayBox(currentTimeframe, currentYear, currentMonth))
-        return UtilityFunctions.getCovidGrayBox(height, width);
+        return UtilityFunctions.getCovidGrayBox(height, width, accessible ? 'By Race/Ethnicity: ' : '');
     else 
-      return UtilityFunctions.getNoDataGrayBoxForEthn(height + (currentDataType == 'percent' ? 80 : 40), width);
+      return UtilityFunctions.getNoDataGrayBoxForEthn(height + (currentDataType == 'percent' ? 80 : 40), width,  accessible ? 'By Race/Ethnicity: ' : '');
   }
 
   if (Number(currentYear) == 2023 && Number(currentMonth) < 12 && currentTimeframe == 'Annual')
   {
-      return UtilityFunctions.getAnnualNoDataGrayBoxForEthn(height + (currentDataType == 'percent' ? 80 : 40), width);
+      return UtilityFunctions.getAnnualNoDataGrayBoxForEthn(height + (currentDataType == 'percent' ? 80 : 40), width, accessible ? 'By Race/Ethnicity: ' : '');
   }
 
   return (

--- a/src/components/EthnicityChart.js
+++ b/src/components/EthnicityChart.js
@@ -595,7 +595,7 @@ function EthnicityChart(params) {
           {!dummy && !UtilityFunctions.dataIsSupressedEthn(filteredData) && 
           <tr>
             <td>
-              {currentDataType == 'rate' && <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div>}
+              {currentDataType == 'placeHolder' && <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div>}
               <div><span><small><i><sup>*</sup>{'The race/ethnicity figure excludes data from jurisdictions that had >= 15% missing race/ethnicity data during the selected time period, as well as those who do not participate in DOSE-SYS or who do not have data for this time period. ' + (areJurisExcluded() ? 'This figure excludes data from ' : '') + getJurisExcluded() + (areJurisExcluded() ? '.' : '')}</i></small></span></div>
               <div><span><small><i><sup>¶</sup>{'AI/AN, American Indian/Alaska Native. NH/PI, Native Hawaiian or other Pacific Islander.'}</i></small></span></div>
             </td>
@@ -612,7 +612,7 @@ function EthnicityChart(params) {
             <br></br>
                     <tr>
                       <td>
-                        {(!dummy && !UtilityFunctions.dataIsSupressedEthn(filteredData)) && currentDataType == 'rate' && <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div> }
+                        {(!dummy && !UtilityFunctions.dataIsSupressedEthn(filteredData)) && currentDataType == 'placeHolder' && <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div> }
                         {<br></br>}
                         <div><span><small><i><sup>*</sup>Data suppressed.</i></small></span></div>
                         {<br></br>}
@@ -674,7 +674,7 @@ function EthnicityChart(params) {
         {!isEthnGrayBox &&
         <div style={{height: !isSmallViewport ? '340px' : '560px'}}>
             <table>
-              {Object.keys(filteredData).length > 0 && currentDataType == 'rate' &&
+              {Object.keys(filteredData).length > 0 && currentDataType == 'placeHolder' &&
                 <tr><td><small><i>{getMissingNote(missingData)}</i></small></td></tr>
               }
               {Object.keys(filteredData).length > 0 &&

--- a/src/components/EthnicityChart.js
+++ b/src/components/EthnicityChart.js
@@ -592,10 +592,10 @@ function EthnicityChart(params) {
             </td>
           </tr>
           }
-          {!dummy && !UtilityFunctions.dataIsSupressedEthn(filteredData) &&
+          {!dummy && !UtilityFunctions.dataIsSupressedEthn(filteredData) && 
           <tr>
             <td>
-              {/* <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div> */}
+              {currentDataType == 'percent' && <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div>}
               <div><span><small><i><sup>*</sup>{'The race/ethnicity figure excludes data from jurisdictions that had >= 15% missing race/ethnicity data during the selected time period, as well as those who do not participate in DOSE-SYS or who do not have data for this time period. ' + (areJurisExcluded() ? 'This figure excludes data from ' : '') + getJurisExcluded() + (areJurisExcluded() ? '.' : '')}</i></small></span></div>
               <div><span><small><i><sup>¶</sup>{'AI/AN, American Indian/Alaska Native. NH/PI, Native Hawaiian or other Pacific Islander.'}</i></small></span></div>
             </td>
@@ -612,8 +612,8 @@ function EthnicityChart(params) {
             <br></br>
                     <tr>
                       <td>
-                        {/* {(!dummy && !UtilityFunctions.dataIsSupressedEthn(filteredData)) && <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div> }
-                        {<br></br>} */}
+                        {(!dummy && !UtilityFunctions.dataIsSupressedEthn(filteredData)) && currentDataType == 'percent' && <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div> }
+                        {<br></br>}
                         <div><span><small><i><sup>*</sup>Data suppressed.</i></small></span></div>
                         {<br></br>}
                         {(!dummy && !UtilityFunctions.dataIsSupressedEthn(filteredData)) && <div><span><small><i><sup>*</sup>{'The race/ethnicity figure excludes data from jurisdictions that had >= 15% missing race/ethnicity data during the selected time period, as well as those who do not participate in DOSE-SYS or who do not have data for this time period.  ' + (areJurisExcluded() ? 'This figure excludes data from ' : '') + getJurisExcluded() + (areJurisExcluded() ? '.' : '')}</i></small></span></div>}
@@ -674,9 +674,9 @@ function EthnicityChart(params) {
         {!isEthnGrayBox &&
         <div style={{height: !isSmallViewport ? '340px' : '560px'}}>
             <table>
-              {/* {Object.keys(filteredData).length > 0 &&
+              {Object.keys(filteredData).length > 0 && currentDataType == 'percent' &&
                 <tr><td><small><i>{getMissingNote(missingData)}</i></small></td></tr>
-              } */}
+              }
               {Object.keys(filteredData).length > 0 &&
                 <tr><td><small><i><sup>*</sup>{'Data suppressed.'}</i></small></td></tr>
               }

--- a/src/components/LineChart.js
+++ b/src/components/LineChart.js
@@ -196,9 +196,7 @@ const getFilteredDataPeriod = (data, currentState, lookupPeriodStartYear, lookup
 
 function LineChart(params) {
 
-  const { data, dataOverall, jurisCountData, monthNames, stateNames, drugOptions, currentTimeframe, currentDrug, currentState, currentYear: currentYearUntyped, currentMonth, width, lookupPeriodStartYear, lookupPeriodStartMonth, lookupPeriodEndYear, lookupPeriodEndMonth, showPercent, showOverall, isPeriod, selectedDrugs, currentDataSource, accessible } = params;
-
-  const [highLightedDrug, setHighlightedDrug] = useState('');
+  const { data, dataOverall, jurisCountData, monthNames, stateNames, drugOptions, currentTimeframe, currentDrug, currentState, currentYear: currentYearUntyped, currentMonth, width, lookupPeriodStartYear, lookupPeriodStartMonth, lookupPeriodEndYear, lookupPeriodEndMonth, showPercent, showOverall, isPeriod, selectedDrugs, currentDataSource, accessible, highlightedDrug } = params;
 
   const currentYear = parseInt(currentYearUntyped);
 
@@ -224,7 +222,7 @@ function LineChart(params) {
     markYearsForTicks();
     adjustCrowdedLabels();
     adjustLinesForLabels();
-    
+    highLightDrug();
   });
 
   const inp = [];
@@ -254,7 +252,7 @@ function LineChart(params) {
   }
   
   const specs = [];
-  specs['width'] = width - 35; 
+  specs['width'] = width - 40; 
   specs['width'] = specs['width'];
   specs['isSmallViewport'] = specs['width'] < 550;
   specs['fontSize'] = !isSmallViewport ? 16 : 14;
@@ -756,20 +754,91 @@ const adjustCrowdedLabels = () => {
       ); 
   }
 
-  function isBold(element) {
-    const computedStyle = window.getComputedStyle(element);
-    const fontWeight = computedStyle.fontWeight;
+const highLightDrug = () => {
 
-    if (fontWeight === 'bold' || parseInt(fontWeight, 10) >= 700) {
-      return true;
+  const allGrps = document?.getElementsByClassName("grpClass");
+
+    if (highlightedDrug == 'none' || highlightedDrug == '' || highlightedDrug === undefined)
+    {
+      Array.prototype.forEach.call(allGrps, function(el) {
+
+            const children = el.children;
+            for (const child of children) {
+                child.style.opacity  = '1';
+            }
+          });
+
+      if (!isSmallViewport) {
+        const allLabels = document?.getElementsByClassName("adjustCrowded");
+        Array.prototype.forEach.call(allLabels, function(el) {
+          let elm = document.getElementById(el.id);
+          elm.style.fontWeight = "normal";
+          elm.style.fontSize = specs.fontSize;
+        });
+      }
     }
-    return false;
-}
+    else
+    {
+      if (!selectedDrugs.includes(highlightedDrug))
+      {
+        
+        Array.prototype.forEach.call(allGrps, function(el) {
 
-  const handleDrugLblClick = (event) => {
+            const children = el.children;
+            for (const child of children) {
+                child.style.opacity  = '1';
+            }
+          });
+
+          if (!isSmallViewport) {
+              const allLabels = document?.getElementsByClassName("adjustCrowded");
+              Array.prototype.forEach.call(allLabels, function(el) {
+                let elm = document.getElementById(el.id);
+                elm.style.fontWeight = "normal";
+                elm.style.fontSize = specs.fontSize;
+            });
+          }
+
+          return;
+      }
+
+      if (!isSmallViewport) {
+            const allLabels = document?.getElementsByClassName("adjustCrowded");
+            Array.prototype.forEach.call(allLabels, function(el) {
+              let elm = document.getElementById(el.id);
+              elm.style.fontWeight = "normal";
+              elm.style.fontSize = specs.fontSize;
+          });
+      }
+
+      Array.prototype.forEach.call(allGrps, function(el) {
+
+        const children = el.children;
+        for (const child of children) {
+            child.style.opacity  = '0.2';
+        }
+
+        if (el.classList.contains('grp-' + highlightedDrug)) {
+          const children = el.children;
+
+          for (const child of children) {
+            child.style.opacity  = '1';
+          }
+
+          if (!isSmallViewport) {
+            let elem = document.getElementById('adjustCrowded-' + highlightedDrug);
+            elem.style.fontWeight = "bold";
+            elem.style.fontSize = specs.fontSize + 2;
+          }
+        }
+        
+      });
+    }
+
+  };
+
+  const handleDrugLblClickTBD = (event) => {
     let elemen = document.getElementById(event.currentTarget.id);
-
-    setHighlightedDrug(event.currentTarget.id.replace('adjustCrowded-',''));
     
     if (isBold(elemen))
     {
@@ -940,7 +1009,6 @@ const adjustCrowdedLabels = () => {
                                 y={yPos}
                                 alignmentBaseline="middle" 
                                 fontSize={specs.fontSize} 
-                                onClick={handleDrugLblClick}
                                 fill={UtilityFunctions.getSeriesColorLine(currentDrug, key, showOverall)}>
                                   {drugOptions[currentDrug].titleForDropDown}
                               </text>
@@ -967,7 +1035,6 @@ const adjustCrowdedLabels = () => {
                                 y={yPos}
                                 alignmentBaseline="middle" 
                                 fontSize={specs.fontSize} 
-                                onClick={handleDrugLblClick}
                                 fill={UtilityFunctions.getSeriesColorLine(currentDrug, key, showOverall)}>
                                   {drugOptions[currentDrug].titleForDropDown}
                               </text>

--- a/src/components/LineChart.js
+++ b/src/components/LineChart.js
@@ -198,6 +198,8 @@ function LineChart(params) {
 
   const { data, dataOverall, jurisCountData, monthNames, stateNames, drugOptions, currentTimeframe, currentDrug, currentState, currentYear: currentYearUntyped, currentMonth, width, lookupPeriodStartYear, lookupPeriodStartMonth, lookupPeriodEndYear, lookupPeriodEndMonth, showPercent, showOverall, isPeriod, selectedDrugs, currentDataSource, accessible } = params;
 
+  const [highLightedDrug, setHighlightedDrug] = useState('');
+
   const currentYear = parseInt(currentYearUntyped);
 
   const isSmallViewport = width < 550;
@@ -222,6 +224,7 @@ function LineChart(params) {
     markYearsForTicks();
     adjustCrowdedLabels();
     adjustLinesForLabels();
+    
   });
 
   const inp = [];
@@ -753,6 +756,69 @@ const adjustCrowdedLabels = () => {
       ); 
   }
 
+  function isBold(element) {
+    const computedStyle = window.getComputedStyle(element);
+    const fontWeight = computedStyle.fontWeight;
+
+    if (fontWeight === 'bold' || parseInt(fontWeight, 10) >= 700) {
+      return true;
+    }
+    return false;
+}
+
+  const handleDrugLblClick = (event) => {
+    let elemen = document.getElementById(event.currentTarget.id);
+
+    setHighlightedDrug(event.currentTarget.id.replace('adjustCrowded-',''));
+    
+    if (isBold(elemen))
+    {
+      elemen.style.fontWeight = "normal";
+      elemen.style.fontSize = specs.fontSize;
+
+      const allGrps = document?.getElementsByClassName("grpClass");
+      Array.prototype.forEach.call(allGrps, function(el) {
+        const drg = el.classList[1].replace('grp-','')
+        const children = el.children;
+        for (const child of children) {
+          child.style.opacity  = '1';
+        }
+      });
+
+      return;
+    }
+    
+    const allLabels = document?.getElementsByClassName("adjustCrowded");
+    Array.prototype.forEach.call(allLabels, function(el) {
+      let elm = document.getElementById(el.id);
+      elm.style.fontWeight = "normal";
+      elm.style.fontSize = specs.fontSize;
+    });
+
+    const allGrps = document?.getElementsByClassName("grpClass");
+    Array.prototype.forEach.call(allGrps, function(el) {
+      const drg = event.currentTarget.id.replace('adjustCrowded-','');
+      if (!el.classList.contains('grp-' + drg)) {
+        const children = el.children;
+
+        for (const child of children) {
+          child.style.opacity  = '0.2';
+        }
+      }
+      else {
+        const children = el.children;
+
+        for (const child of children) {
+           child.style.opacity  = '1';
+        }
+      }
+    });
+
+    let elem = document.getElementById(event.currentTarget.id);
+    elem.style.fontWeight = "bold";
+    elem.style.fontSize = specs.fontSize + 2;
+  };
+
   const buildLineForDrug = (currentDrug) => {
 
     const sectionWidth = specs.xMax / specs.xValues.length;
@@ -781,7 +847,7 @@ const adjustCrowdedLabels = () => {
                       const dPrev = i > 0  ? inp.filteredData[key].find(d => d[specs.xKey] === specs.xValues[i - 1]) || {} : {}
 
                       return (
-                        <Group key={`line-path-${key}-point-${i}`}>
+                        <Group key={`line-path-${key}-point-${i}`} class={`grpClass grp-${currentDrug}`}>
                           {(!isNaN(d[currentDrug]) && !isNaN(dNext[currentDrug]) && d[currentDrug] >= 0 && (dNext[currentDrug] >= 0 && !UtilityFunctions.isCovidPeriodNoLine(currentTimeframe, dNext['year'], d['year'])) && key == 'US' && (currentState == 'US' || (currentState != 'US' && showOverall))) && 
                             <line x1={specs.xScale(d[specs.xKey]) ?? 0} y1={(d[currentDrug] == '0.0' ? specs.yScale(0) - 2 : specs.yScale(d[currentDrug])) ?? 0} x2={specs.xScale(dNext[specs.xKey]) ?? 0} y2={(dNext[currentDrug] == '0.0' ? specs.yScale(0) - 2 : specs.yScale(dNext[currentDrug])) ?? 0} stroke={UtilityFunctions.getSeriesColorLine(currentDrug, key, showOverall)} strokeWidth={3} />
                           }
@@ -868,11 +934,13 @@ const adjustCrowdedLabels = () => {
                                 stroke={colorScale[currentDrug]}
                                 strokeWidth={0.5}/>
                               <text
+                                id={`adjustCrowded-${currentDrug}`}
                                 class={'adjustCrowded'}
                                 x={specs.xMax + 28} 
                                 y={yPos}
                                 alignmentBaseline="middle" 
                                 fontSize={specs.fontSize} 
+                                onClick={handleDrugLblClick}
                                 fill={UtilityFunctions.getSeriesColorLine(currentDrug, key, showOverall)}>
                                   {drugOptions[currentDrug].titleForDropDown}
                               </text>
@@ -893,11 +961,13 @@ const adjustCrowdedLabels = () => {
                                 stroke={colorScale[currentDrug]}
                                 strokeWidth={0.5}/>
                               <text
+                                id={`adjustCrowded-${currentDrug}`}
                                 class='adjustCrowded'
                                 x={specs.xMax + 28} 
                                 y={yPos}
                                 alignmentBaseline="middle" 
                                 fontSize={specs.fontSize} 
+                                onClick={handleDrugLblClick}
                                 fill={UtilityFunctions.getSeriesColorLine(currentDrug, key, showOverall)}>
                                   {drugOptions[currentDrug].titleForDropDown}
                               </text>

--- a/src/components/LineChart.js
+++ b/src/components/LineChart.js
@@ -941,7 +941,7 @@ const adjustCrowdedLabels = () => {
             'opioids': !isSmallViewport ? 'All Opioids' : 'All Opioids',
             'stimulants': !isSmallViewport ? 'All Stimulants' : 'All Stimulants',
             'Overall': !isSmallViewport ? 'Overall' : 'Overall',
-            'Year/Month': 'Month Year',
+            'Year/Month': (currentTimeframe == 'Annual' ? '12 months ending in:' : 'Month Year'),
           }}
           xAxisKey={'Year/Month'}
           transforms={{

--- a/src/components/SexAgeChart.js
+++ b/src/components/SexAgeChart.js
@@ -451,7 +451,7 @@ function SexAgeChart(params) {
           currentDataType={currentDataType}
         />
         {!isSmallViewport && <table>
-          {!UtilityFunctions.allDataIsSupressedSA(filteredData) && currentDataType == 'rate' &&
+          {!UtilityFunctions.allDataIsSupressedSA(filteredData) && currentDataType == 'placeHolder' &&
           <tr>
             <td>
               <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div>
@@ -470,7 +470,7 @@ function SexAgeChart(params) {
                     <tr>
                       <td>
                         <div><span><small><i><sup>*</sup>Data suppressed.</i></small></span></div>
-                        {!UtilityFunctions.allDataIsSupressedSA(filteredData) && currentDataType == 'rate' && <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div> }
+                        {!UtilityFunctions.allDataIsSupressedSA(filteredData) && currentDataType == 'placeHolder' && <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div> }
                         <span></span>
                       </td>
                     </tr>
@@ -544,7 +544,7 @@ function SexAgeChart(params) {
       </svg>
       <div style={{height: (isEthnGrayBox ? (isSmallViewport ? (currentDataType == 'rate' ? '160px' : '210px') : (currentDataType == 'rate' ? '100px' : '140px')) : (isSmallViewport ? (currentDataType == 'rate' ? '180px' : '230px') : '340px'))}}>
         <table>
-          {!UtilityFunctions.allDataIsSupressedSA(filteredData) && currentDataType == 'rate' &&
+          {!UtilityFunctions.allDataIsSupressedSA(filteredData) && currentDataType == 'placeHolder' &&
             <tr><td><small><i>{getMissingNote(missingData)}</i></small></td></tr>
           }
           {!UtilityFunctions.allDataIsSupressedSA(filteredData) &&

--- a/src/components/SexAgeChart.js
+++ b/src/components/SexAgeChart.js
@@ -450,7 +450,7 @@ function SexAgeChart(params) {
           drugName={drugOptions[currentDrug].titleAll}
           currentDataType={currentDataType}
         />
-        {!isSmallViewport && <table>
+        {/* {!isSmallViewport && <table>
           {!UtilityFunctions.allDataIsSupressedSA(filteredData) &&
           <tr>
             <td>
@@ -459,7 +459,7 @@ function SexAgeChart(params) {
           </tr>
           }
         </table>
-        }
+        } */}
         {isSmallViewport && <table>
           <tr>
               <td>
@@ -470,7 +470,7 @@ function SexAgeChart(params) {
                     <tr>
                       <td>
                         <div><span><small><i><sup>*</sup>Data suppressed.</i></small></span></div>
-                        {!UtilityFunctions.allDataIsSupressedSA(filteredData) && <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div> }
+                        {/* {!UtilityFunctions.allDataIsSupressedSA(filteredData) && <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div> } */}
                         <span></span>
                       </td>
                     </tr>
@@ -542,11 +542,11 @@ function SexAgeChart(params) {
           {<text x={!isSmallViewport ? xMax/2 : 80} y={yMax+ 90} fill={'#000066'} fontSize={fontSize * (isSmallViewport ? .8 : 1)} textAnchor="middle">{(currentDataType == 'rate' ?  '' : 'Involving ') + drugOptions[currentDrug].titleAll + (currentDataType == 'rate' ?  ' per 10,000 Total ED visits' : '')}</text>}
         </Group>
       </svg>
-      <div style={{height: (isEthnGrayBox ? (isSmallViewport ? (currentDataType == 'rate' ? '160px' : '210px') : (currentDataType == 'rate' ? '100px' : '140px')) : (isSmallViewport ? (currentDataType == 'rate' ? '180px' : '230px') : '320px'))}}>
+      <div style={{height: (isEthnGrayBox ? (isSmallViewport ? (currentDataType == 'rate' ? '160px' : '210px') : (currentDataType == 'rate' ? '100px' : '140px')) : (isSmallViewport ? (currentDataType == 'rate' ? '180px' : '230px') : '340px'))}}>
         <table>
-          {!UtilityFunctions.allDataIsSupressedSA(filteredData) &&
+          {/* {!UtilityFunctions.allDataIsSupressedSA(filteredData) &&
             <tr><td><small><i>{getMissingNote(missingData)}</i></small></td></tr>
-          }
+          } */}
           {!UtilityFunctions.allDataIsSupressedSA(filteredData) &&
             <tr><td><small><i><sup>*</sup>{'Data suppressed.'}</i></small></td></tr>
           }

--- a/src/components/SexAgeChart.js
+++ b/src/components/SexAgeChart.js
@@ -450,8 +450,8 @@ function SexAgeChart(params) {
           drugName={drugOptions[currentDrug].titleAll}
           currentDataType={currentDataType}
         />
-        {/* {!isSmallViewport && <table>
-          {!UtilityFunctions.allDataIsSupressedSA(filteredData) &&
+        {!isSmallViewport && <table>
+          {!UtilityFunctions.allDataIsSupressedSA(filteredData) && currentDataType == 'percent' &&
           <tr>
             <td>
               <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div>
@@ -459,7 +459,7 @@ function SexAgeChart(params) {
           </tr>
           }
         </table>
-        } */}
+        }
         {isSmallViewport && <table>
           <tr>
               <td>
@@ -470,7 +470,7 @@ function SexAgeChart(params) {
                     <tr>
                       <td>
                         <div><span><small><i><sup>*</sup>Data suppressed.</i></small></span></div>
-                        {/* {!UtilityFunctions.allDataIsSupressedSA(filteredData) && <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div> } */}
+                        {!UtilityFunctions.allDataIsSupressedSA(filteredData) && currentDataType == 'percent' && <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div> }
                         <span></span>
                       </td>
                     </tr>
@@ -544,9 +544,9 @@ function SexAgeChart(params) {
       </svg>
       <div style={{height: (isEthnGrayBox ? (isSmallViewport ? (currentDataType == 'rate' ? '160px' : '210px') : (currentDataType == 'rate' ? '100px' : '140px')) : (isSmallViewport ? (currentDataType == 'rate' ? '180px' : '230px') : '340px'))}}>
         <table>
-          {/* {!UtilityFunctions.allDataIsSupressedSA(filteredData) &&
+          {!UtilityFunctions.allDataIsSupressedSA(filteredData) && currentDataType == 'percent' &&
             <tr><td><small><i>{getMissingNote(missingData)}</i></small></td></tr>
-          } */}
+          }
           {!UtilityFunctions.allDataIsSupressedSA(filteredData) &&
             <tr><td><small><i><sup>*</sup>{'Data suppressed.'}</i></small></td></tr>
           }

--- a/src/components/SexAgeChart.js
+++ b/src/components/SexAgeChart.js
@@ -286,7 +286,7 @@ const getAgeGroups = (data, currentTimeLine, currentYear, currentMonth) => {
 
 function SexAgeChart(params) {
 
-  const { data, currentTimeframe, currentDrug, currentYear, currentMonth, currentDataType, width, height, drugOptions, accessible, widthReduction, isEthnGrayBox } = params;
+  const { data, jurisCountData, currentTimeframe, currentDrug, currentYear, currentMonth, currentDataType, width, height, drugOptions, accessible, widthReduction, isEthnGrayBox } = params;
 
   const ageGroups = getAgeGroups(data, currentTimeframe, currentYear, currentMonth)
   const filteredData = getFilteredData(data, ageGroups, currentDrug, currentTimeframe, currentYear, currentMonth, currentDataType);
@@ -423,7 +423,7 @@ function SexAgeChart(params) {
     )
   }
 
-  if (!accessible && UtilityFunctions.isCovidPeriodGrayBox(currentTimeframe, currentYear, currentMonth))
+  if (UtilityFunctions.isCovidPeriodGrayBox(currentTimeframe, currentYear, currentMonth))
         return UtilityFunctions.getCovidGrayBox(height, width);
 
   return (
@@ -433,8 +433,8 @@ function SexAgeChart(params) {
         <DataTable508
           data={AccessibilityFunctions.generateSexAgeChartData(filteredData)}
           labelOverrides={{
-            'rate': !isSmallViewport ? (currentDataType == 'rate' ? 'Rate' : 'Percent') + ' of suspected nonfatal overdoses involving ' + drugOptions[currentDrug].titleAll + ' per 10,000 Total ED Visits' : (currentDataType == 'rate' ? 'Rate' : 'Percent'),
-            'Age Group': !isSmallViewport ? 'By Age (In years) and Sex' : 'By Age and Sex',
+            'rate': !isSmallViewport ? (currentDataType == 'rate' ? 'Rate' : 'Percent') + ' of suspected nonfatal overdoses involving ' + drugOptions[currentDrug].titleAll + (currentDataType == 'rate' ? ' per 10,000 Total ED Visits' : '') : (currentDataType == 'rate' ? 'Rate' : 'Percent'),
+            'Age Group': (!isSmallViewport ? 'By Age (In years) and Sex (' : 'By Age and Sex (') + ((jurisCountData != null && Object.keys(jurisCountData).length > 0) ? jurisCountData[currentYear + currentMonth.padStart(2, '0') + currentTimeframe] : '0') + ' Jurisdictions)',
             'Female': !isSmallViewport ? 'Female' : 'Female',
             'Male': !isSmallViewport ? 'Male' : 'Male',
             '0–14': '<15'
@@ -454,7 +454,7 @@ function SexAgeChart(params) {
           {!UtilityFunctions.allDataIsSupressedSA(filteredData) &&
           <tr>
             <td>
-              <div><span><small><i><sup>*</sup>{getMissingNote(missingData)}</i></small></span></div>
+              <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div>
             </td>
           </tr>
           }
@@ -494,7 +494,7 @@ function SexAgeChart(params) {
             textAnchor: 'end',
             verticalAnchor: 'middle',
           })}
-          left={!isSmallViewport ? 30 : 10}
+          left={!isSmallViewport ? (currentDataType == 'rate' ? 30 : 10) : 10}
           hideTicks
           hideAxisLine
         />
@@ -542,7 +542,7 @@ function SexAgeChart(params) {
           {<text x={!isSmallViewport ? xMax/2 : 80} y={yMax+ 90} fill={'#000066'} fontSize={fontSize * (isSmallViewport ? .8 : 1)} textAnchor="middle">{(currentDataType == 'rate' ?  '' : 'Involving ') + drugOptions[currentDrug].titleAll + (currentDataType == 'rate' ?  ' per 10,000 Total ED visits' : '')}</text>}
         </Group>
       </svg>
-      <div style={{height: (isEthnGrayBox ? (isSmallViewport ? (currentDataType == 'rate' ? '160px' : '210px') : (currentDataType == 'rate' ? '100px' : '140px')) : (isSmallViewport ? (currentDataType == 'rate' ? '160px' : '210px') : '300px'))}}>
+      <div style={{height: (isEthnGrayBox ? (isSmallViewport ? (currentDataType == 'rate' ? '160px' : '210px') : (currentDataType == 'rate' ? '100px' : '140px')) : (isSmallViewport ? (currentDataType == 'rate' ? '180px' : '230px') : '320px'))}}>
         <table>
           {!UtilityFunctions.allDataIsSupressedSA(filteredData) &&
             <tr><td><small><i>{getMissingNote(missingData)}</i></small></td></tr>

--- a/src/components/SexAgeChart.js
+++ b/src/components/SexAgeChart.js
@@ -451,7 +451,7 @@ function SexAgeChart(params) {
           currentDataType={currentDataType}
         />
         {!isSmallViewport && <table>
-          {!UtilityFunctions.allDataIsSupressedSA(filteredData) && currentDataType == 'percent' &&
+          {!UtilityFunctions.allDataIsSupressedSA(filteredData) && currentDataType == 'rate' &&
           <tr>
             <td>
               <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div>
@@ -470,7 +470,7 @@ function SexAgeChart(params) {
                     <tr>
                       <td>
                         <div><span><small><i><sup>*</sup>Data suppressed.</i></small></span></div>
-                        {!UtilityFunctions.allDataIsSupressedSA(filteredData) && currentDataType == 'percent' && <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div> }
+                        {!UtilityFunctions.allDataIsSupressedSA(filteredData) && currentDataType == 'rate' && <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div> }
                         <span></span>
                       </td>
                     </tr>
@@ -544,7 +544,7 @@ function SexAgeChart(params) {
       </svg>
       <div style={{height: (isEthnGrayBox ? (isSmallViewport ? (currentDataType == 'rate' ? '160px' : '210px') : (currentDataType == 'rate' ? '100px' : '140px')) : (isSmallViewport ? (currentDataType == 'rate' ? '180px' : '230px') : '340px'))}}>
         <table>
-          {!UtilityFunctions.allDataIsSupressedSA(filteredData) && currentDataType == 'percent' &&
+          {!UtilityFunctions.allDataIsSupressedSA(filteredData) && currentDataType == 'rate' &&
             <tr><td><small><i>{getMissingNote(missingData)}</i></small></td></tr>
           }
           {!UtilityFunctions.allDataIsSupressedSA(filteredData) &&

--- a/src/components/SexAgeChart.js
+++ b/src/components/SexAgeChart.js
@@ -424,7 +424,7 @@ function SexAgeChart(params) {
   }
 
   if (UtilityFunctions.isCovidPeriodGrayBox(currentTimeframe, currentYear, currentMonth))
-        return UtilityFunctions.getCovidGrayBox(height, width);
+        return UtilityFunctions.getCovidGrayBox(height, width, accessible ? 'By Age (In years) and Sex: ' : '');
 
   return (
     <>

--- a/src/components/SexChart.js
+++ b/src/components/SexChart.js
@@ -200,7 +200,7 @@ const getMaxValue = (fdata) => {
 
 function SexChart(params) {
 
-  const { data, width, height, el, currentDrug, drugOptions, currentTimeLine, currentYear, currentMonth, currentDataType, accessible, widthReduction } = params;
+  const { data, jurisCountData, width, height, el, currentDrug, drugOptions, currentTimeLine, currentYear, currentMonth, currentDataType, accessible, widthReduction } = params;
 
   const isSmallViewport = width < 550 && !widthReduction;
   
@@ -214,7 +214,6 @@ function SexChart(params) {
   const adjustedWidth = width - margin.left - margin.right;
   const fontSize = 16;
 
-  
   const xScale = scaleBand({
     domain: filteredData.map(d => d.sex),
     range: [ 0, adjustedWidth ],
@@ -254,7 +253,7 @@ function SexChart(params) {
     setTimeout(onScroll, 50); // eslint-disable-next-line
   }, []);
 
-  if (!accessible && UtilityFunctions.isCovidPeriodGrayBox(currentTimeLine, currentYear, currentMonth))
+  if (UtilityFunctions.isCovidPeriodGrayBox(currentTimeLine, currentYear, currentMonth))
         return UtilityFunctions.getCovidGrayBox(height, width);
     
   return width > 0 && 
@@ -265,8 +264,8 @@ function SexChart(params) {
         <DataTable508
           data={AccessibilityFunctions.generateSexChartData(filteredData)}
           labelOverrides={{
-            'rate': !isSmallViewport ? (currentDataType == 'rate' ? 'Rate' : 'Percent') + ' of suspected nonfatal overdoses involving ' + drugOptions[currentDrug].titleAll + ' per 10,000 Total ED Visits' : (currentDataType == 'rate' ? 'Rate' : 'Percent'),
-            'Sex': 'By Sex'
+            'rate': !isSmallViewport ? (currentDataType == 'rate' ? 'Rate' : 'Percent') + ' of suspected nonfatal overdoses involving ' + drugOptions[currentDrug].titleAll + (currentDataType == 'rate' ? ' per 10,000 Total ED Visits' : '') : (currentDataType == 'rate' ? 'Rate' : 'Percent'),
+            'Sex': 'By Sex (' + ((jurisCountData != null && Object.keys(jurisCountData).length > 0) ? jurisCountData[currentYear + currentMonth.padStart(2, '0') + currentTimeLine] : '0') + ' Jurisdictions)'
           }}
           xAxisKey={'Sex'}
           transforms={{
@@ -327,6 +326,7 @@ function SexChart(params) {
                       getFormattedValue(value)
                   }
                   labelOffset={60}
+                  numTicks={5}
                 />
 
                 {filteredData.map(d => (

--- a/src/components/SexChart.js
+++ b/src/components/SexChart.js
@@ -277,7 +277,7 @@ function SexChart(params) {
           currentDataType={currentDataType}
         />
         {!isSmallViewport && <table>
-            {!UtilityFunctions.allDataIsSupressed(filteredData) && currentDataType == 'rate' &&
+            {!UtilityFunctions.allDataIsSupressed(filteredData) && currentDataType == 'placeHolder' &&
             <tr>
               <td>
                 <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div>
@@ -297,7 +297,7 @@ function SexChart(params) {
             <tr>
               <td>
                 <div><span><small><i><sup>*</sup>Data suppressed.</i></small></span></div>
-                {!UtilityFunctions.allDataIsSupressed(filteredData) && currentDataType == 'rate' && <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div> }
+                {!UtilityFunctions.allDataIsSupressed(filteredData) && currentDataType == 'placeHolder' && <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div> }
                 <span></span>
               </td>
             </tr>
@@ -406,7 +406,7 @@ function SexChart(params) {
         </svg>
         <div>
           <table>
-            {!UtilityFunctions.allDataIsSupressed(filteredData) && currentDataType == 'rate' &&
+            {!UtilityFunctions.allDataIsSupressed(filteredData) && currentDataType == 'placeHolder' &&
               <tr><td><small><i>{getMissingNote(missingData)}</i></small></td></tr>
             }
             {!UtilityFunctions.allDataIsSupressed(filteredData) &&

--- a/src/components/SexChart.js
+++ b/src/components/SexChart.js
@@ -276,7 +276,7 @@ function SexChart(params) {
           isSmallViewport={isSmallViewport}
           currentDataType={currentDataType}
         />
-        {!isSmallViewport && <table>
+        {/* {!isSmallViewport && <table>
             {!UtilityFunctions.allDataIsSupressed(filteredData) &&
             <tr>
               <td>
@@ -286,7 +286,7 @@ function SexChart(params) {
             </tr>
             }
         </table>
-        }
+        } */}
         {isSmallViewport && <table>
           <tr>
               <td>
@@ -297,7 +297,7 @@ function SexChart(params) {
             <tr>
               <td>
                 <div><span><small><i><sup>*</sup>Data suppressed.</i></small></span></div>
-                {!UtilityFunctions.allDataIsSupressed(filteredData) && <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div> }
+                {/* {!UtilityFunctions.allDataIsSupressed(filteredData) && <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div> } */}
                 <span></span>
               </td>
             </tr>
@@ -406,9 +406,9 @@ function SexChart(params) {
         </svg>
         <div>
           <table>
-            {!UtilityFunctions.allDataIsSupressed(filteredData) &&
+            {/* {!UtilityFunctions.allDataIsSupressed(filteredData) &&
               <tr><td><small><i>{getMissingNote(missingData)}</i></small></td></tr>
-            }
+            } */}
             {!UtilityFunctions.allDataIsSupressed(filteredData) &&
               <tr><td><small><i><sup>*</sup>{'Data suppressed.'}</i></small></td></tr>
             }

--- a/src/components/SexChart.js
+++ b/src/components/SexChart.js
@@ -276,8 +276,8 @@ function SexChart(params) {
           isSmallViewport={isSmallViewport}
           currentDataType={currentDataType}
         />
-        {/* {!isSmallViewport && <table>
-            {!UtilityFunctions.allDataIsSupressed(filteredData) &&
+        {!isSmallViewport && <table>
+            {!UtilityFunctions.allDataIsSupressed(filteredData) && currentDataType == 'percent' &&
             <tr>
               <td>
                 <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div>
@@ -286,7 +286,7 @@ function SexChart(params) {
             </tr>
             }
         </table>
-        } */}
+        }
         {isSmallViewport && <table>
           <tr>
               <td>
@@ -297,7 +297,7 @@ function SexChart(params) {
             <tr>
               <td>
                 <div><span><small><i><sup>*</sup>Data suppressed.</i></small></span></div>
-                {/* {!UtilityFunctions.allDataIsSupressed(filteredData) && <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div> } */}
+                {!UtilityFunctions.allDataIsSupressed(filteredData) && currentDataType == 'percent' && <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div> }
                 <span></span>
               </td>
             </tr>
@@ -406,9 +406,9 @@ function SexChart(params) {
         </svg>
         <div>
           <table>
-            {/* {!UtilityFunctions.allDataIsSupressed(filteredData) &&
+            {!UtilityFunctions.allDataIsSupressed(filteredData) && currentDataType == 'percent' &&
               <tr><td><small><i>{getMissingNote(missingData)}</i></small></td></tr>
-            } */}
+            }
             {!UtilityFunctions.allDataIsSupressed(filteredData) &&
               <tr><td><small><i><sup>*</sup>{'Data suppressed.'}</i></small></td></tr>
             }

--- a/src/components/SexChart.js
+++ b/src/components/SexChart.js
@@ -254,7 +254,7 @@ function SexChart(params) {
   }, []);
 
   if (UtilityFunctions.isCovidPeriodGrayBox(currentTimeLine, currentYear, currentMonth))
-        return UtilityFunctions.getCovidGrayBox(height, width);
+        return UtilityFunctions.getCovidGrayBox(height, width, accessible ? 'By Sex: ' : '');
     
   return width > 0 && 
       (

--- a/src/components/SexChart.js
+++ b/src/components/SexChart.js
@@ -277,7 +277,7 @@ function SexChart(params) {
           currentDataType={currentDataType}
         />
         {!isSmallViewport && <table>
-            {!UtilityFunctions.allDataIsSupressed(filteredData) && currentDataType == 'percent' &&
+            {!UtilityFunctions.allDataIsSupressed(filteredData) && currentDataType == 'rate' &&
             <tr>
               <td>
                 <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div>
@@ -297,7 +297,7 @@ function SexChart(params) {
             <tr>
               <td>
                 <div><span><small><i><sup>*</sup>Data suppressed.</i></small></span></div>
-                {!UtilityFunctions.allDataIsSupressed(filteredData) && currentDataType == 'percent' && <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div> }
+                {!UtilityFunctions.allDataIsSupressed(filteredData) && currentDataType == 'rate' && <div><span><small><i>{getMissingNote(missingData)}</i></small></span></div> }
                 <span></span>
               </td>
             </tr>
@@ -406,7 +406,7 @@ function SexChart(params) {
         </svg>
         <div>
           <table>
-            {!UtilityFunctions.allDataIsSupressed(filteredData) && currentDataType == 'percent' &&
+            {!UtilityFunctions.allDataIsSupressed(filteredData) && currentDataType == 'rate' &&
               <tr><td><small><i>{getMissingNote(missingData)}</i></small></td></tr>
             }
             {!UtilityFunctions.allDataIsSupressed(filteredData) &&

--- a/src/components/StateChart.js
+++ b/src/components/StateChart.js
@@ -216,7 +216,7 @@ function StateChart(params) {
       return drugOptions[currentDrug].titleForDropDown + ' per 10,000 Total ED Visits';
   }
 
-  if (!accessible && UtilityFunctions.isCovidPeriodGrayBox(currentTimeframe, currentYear, currentMonth))
+  if (UtilityFunctions.isCovidPeriodGrayBox(currentTimeframe, currentYear, currentMonth))
         return UtilityFunctions.getCovidGrayBox(height, width);
 
   return width > 0 && (

--- a/src/utility.js
+++ b/src/utility.js
@@ -832,4 +832,13 @@ export const UtilityFunctions = {
        
   },
 
+  isBold : (element) => {
+    const computedStyle = window.getComputedStyle(element);
+    const fontWeight = computedStyle.fontWeight;
+
+    if (fontWeight === 'bold' || parseInt(fontWeight, 10) >= 700) {
+      return true;
+    }
+    return false;
+  },
 }

--- a/src/utility.js
+++ b/src/utility.js
@@ -800,32 +800,32 @@ export const UtilityFunctions = {
     return (ret != fdata.length-1 && ret/yMax > 0.3) ? true : false;
   },
   
-  getCovidGrayBox : (hgt, wid) => {
+  getCovidGrayBox : (hgt, wid, forTitle) => {
     return (
       <Fragment>
         <>
-        <div style={{ height: hgt - 100, width: wid, textAlign: 'left', display: 'flex', alignItems: 'center', backgroundColor: '#E7E7E7', fontWeight: 'bold', borderRadius: '30px'}}><p style={{ textAlign: 'left', fontWeight: 'bold', padding: '20px'}}>Grayed out figure represents the COVID-19 pandemic and is distinct from data suppression for other reasons.</p></div>
+        <div style={{ height: hgt - 100, width: wid, textAlign: 'left', display: 'flex', alignItems: 'center', backgroundColor: '#E7E7E7', fontWeight: 'bold', borderRadius: '30px'}}><p style={{ textAlign: 'left', fontWeight: 'bold', padding: '20px'}}><strong>{forTitle}</strong>Grayed out figure represents the COVID-19 pandemic and is distinct from data suppression for other reasons.</p></div>
         </>
         </Fragment>
         )
   },
 
-  getNoDataGrayBoxForEthn : (hgt, wid) => {
+  getNoDataGrayBoxForEthn : (hgt, wid, forTitle) => {
     return (
       <Fragment>
         <>
-        <div style={{ height: hgt + 40, width: wid, textAlign: 'left', display: 'flex', alignItems: 'center', backgroundColor: '#E7E7E7', fontWeight: 'bold', borderRadius: '30px'}}><p style={{ textAlign: 'left', fontWeight: 'bold', padding: '20px'}}>Grayed out figure represents time periods where race/ethnicity data missingness is greater than 10% and is distinct from data suppression for other reasons. </p></div>
+        <div style={{ height: hgt + 40, width: wid, textAlign: 'left', display: 'flex', alignItems: 'center', backgroundColor: '#E7E7E7', fontWeight: 'bold', borderRadius: '30px'}}><p style={{ textAlign: 'left', fontWeight: 'bold', padding: '20px'}}><strong>{forTitle}</strong>Grayed out figure represents time periods where race/ethnicity data missingness is greater than 10% and is distinct from data suppression for other reasons. </p></div>
         </>
         </Fragment>
         )
        
   },
 
-  getAnnualNoDataGrayBoxForEthn : (hgt, wid) => {
+  getAnnualNoDataGrayBoxForEthn : (hgt, wid, forTitle) => {
     return (
       <Fragment>
         <>
-        <div style={{ height: hgt + 40, width: wid, textAlign: 'left', display: 'flex', alignItems: 'center', backgroundColor: '#E7E7E7', fontWeight: 'bold', borderRadius: '30px'}}><p style={{ textAlign: 'left', fontWeight: 'bold', padding: '20px'}}>For annual rates, data are available starting with the 12-month period ending in December 2023. Race/ethnicity data prior to 2023 are not shown due to race/ethnicity missingness greater than 10%.</p></div>
+        <div style={{ height: hgt + 40, width: wid, textAlign: 'left', display: 'flex', alignItems: 'center', backgroundColor: '#E7E7E7', fontWeight: 'bold', borderRadius: '30px'}}><p style={{ textAlign: 'left', fontWeight: 'bold', padding: '20px'}}><strong>{forTitle}</strong>For annual rates, data are available starting with the 12-month period ending in December 2023. Race/ethnicity data prior to 2023 are not shown due to race/ethnicity missingness greater than 10%.</p></div>
         </>
         </Fragment>
         )


### PR DESCRIPTION
UAT Findings/New Business Requirements:

1.	IDEA-S 3: Possible, if low lift (need to discuss). In the trend figure, a lot of the drug indicators with low rates overlap (if viewed at once), and it’s hard to visualize which line pertains to which drug. It would be nice if a user could click on a drug name on the right (I put a red box around where I mean) [or in the drug button section above figure?] and it could bring the line for that drug to the front. It seems that meth is always at the front/on top of other drug indicators; it’d be nice if I could choose, e.g., for heroin to be on top/front. [Note that rates are at least available in hover-over box already.]
2.	IDEA-S 36: "Note" below all demographic figures to include the following text when the "Percent" toggle is selected: "Percentages in the figure may not add up to 100% due to missingness."
3.	IDEA-S 39: Is it possible to make the R/E text labels horizontal instead of slanted? Maybe "other or multiple race" could be wrapped?
4.	IDEA-S 40: I think we need a footnote next to AI/AN and NH/PI to define these. it could be the little paragraph symbol ¶ The actual footnote would be last in the footnote list immediately below the figure and say: ¶AI/AN, American Indian/Alaska Native. NH/PI, Native Hawaiian or other Pacific Islander.
5.	IDEA-S 41: Please remove the * symbol (i.e., the asterisk) next to the *Note underneath the age-by-sex and race/ethnicity figures.
6.	IDEA-S 42: The demographic tables need to have the number of included jurisdictions in parentheses. This is a big one! (it needs to match Accessibility view) needs to match Interactive view: e.g., it should say, "By Sex (45 Jurisdictions)" <-- the highlighted part is what needs to be added (with the number of jurisdictions adjusting dynamically)
7.	IDEA-S 43: In addition, for the R/E table specifically, there needs to be a footnote symbol that links to the footnote about "The race/ethnicity figure excludes data from jurisdictions that had >= 15% missing race/ethnicity data during the selected time period, as well as those who do not participate in DOSE-SYS or who do not have data for this time period. This figure excludes data from Alabama, California, District of Columbia, Louisiana, Maine, Missouri, North Carolina, North Dakota, New Hampshire, New Jersey, New York, Ohio, Oklahoma and Texas." My 2 recommended edits are: a. For the subtitle, add a footnote symbol (asterisk ), i.e.: 2. Add an asterisk to the following footnote: *The race/ethnicity figure excludes data from jurisdictions that had >= 15% missing race/ethnicity data during the selected time period, as well as those who do not participate in DOSE-SYS or who do not have data for this time period. This figure excludes data from Alabama, California, District of Columbia, Louisiana, Maine, Missouri, North Carolina, North Dakota, New Hampshire, New Jersey, New York, Ohio, Oklahoma and Texas.
8.	IDEA-S 44: Please edit demographic section banner title as follows (remove 2 words): "Suspected Nonfatal Overdose ED Visits.... by Sex, Age, and by Sex and Age, and Race/Ethnicity..."
9.	IDEA-S 45: Need footnote to define AI/AN and NH/PI. See below:
10.	IDEA-S 46: Applies to multiple tables: Please tweak the "Note" below the "Select Time Period" as follows:
11.	IDEA-S 47: Applies to the "%" selection for all demographic tables: please remove "per 10,000 Total ED visits" from the column title:
12.	IDEA-S 48: All demographic figures: Please ensure the missingness "Note" for the Accessibility view also includes the text "Percentages in the figure may not add up to 100% due to missingness." I.e., the highlighted part below (screenshot from interactive view) is missing from the "Note" on the Accessibility view.
13.	IDEA-S 49: Can we change this (current screenshot of SYS Accessibility view) to this (current view of SYS Interactive view, for the same time period; conveys more information):
14.	IDEA-S 50: replace tables like this (first screenshot; during COVID-19 period; current view on SYS Accessibility view) to say this, which is the new format we are using for the Interactive view now?: I.e., the current table format for Accessibility view during the C-19 period does not explain why the data are suppressed; the second gray box conveys more information/explains it. I'd like to be consistent

Thanks.

